### PR TITLE
Fix breadcrumb ellipsis displayName

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -102,7 +102,7 @@ const BreadcrumbEllipsis = ({
     <span className="sr-only">More</span>
   </span>
 )
-BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+BreadcrumbEllipsis.displayName = "BreadcrumbEllipsis"
 
 export {
   Breadcrumb,


### PR DESCRIPTION
## Summary
- fix `BreadcrumbEllipsis.displayName` typo

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d4494e2b88326a9e0c5bdcbba2871