### PR TITLE
Fix property typo for existing slot clearing

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -130,7 +130,7 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices }: BOMBuilderProps) => {
         const updated = { ...prev };
         
         if (placement.shouldClearExisting) {
-          placement.existingSlotsTolear.forEach(slotToClear => {
+          placement.existingSlotsToClear.forEach(slotToClear => {
             delete updated[slotToClear];
           });
         }

--- a/src/components/bom/QTMSConfigurationEditor.tsx
+++ b/src/components/bom/QTMSConfigurationEditor.tsx
@@ -116,7 +116,7 @@ const QTMSConfigurationEditor = ({
         
         // Clear existing bushing cards
         if (placement.shouldClearExisting) {
-          placement.existingSlotsTolear.forEach(slotToClear => {
+          placement.existingSlotsToClear.forEach(slotToClear => {
             delete updated[slotToClear];
           });
         }

--- a/src/utils/bushingValidation.ts
+++ b/src/utils/bushingValidation.ts
@@ -11,7 +11,10 @@ export interface BushingPlacement {
   primarySlot: number;
   secondarySlot: number;
   shouldClearExisting: boolean;
-  existingSlotsTolear: number[];
+  /**
+   * Slots that should be cleared before placing a new bushing card
+   */
+  existingSlotsToClear: number[];
 }
 
 export const getBushingSlotConfiguration = (chassisType: string): { allowedPlacements: number[][] } => {
@@ -50,7 +53,7 @@ export const findOptimalBushingPlacement = (
         primarySlot,
         secondarySlot,
         shouldClearExisting: existingBushingSlots.length > 0,
-        existingSlotsTolear: existingBushingSlots
+        existingSlotsToClear: existingBushingSlots
       };
     }
   }
@@ -67,7 +70,7 @@ export const findOptimalBushingPlacement = (
         primarySlot: fallbackPrimary,
         secondarySlot: fallbackSecondary,
         shouldClearExisting: existingBushingSlots.length > 0,
-        existingSlotsTolear: existingBushingSlots
+        existingSlotsToClear: existingBushingSlots
       };
     }
     
@@ -77,7 +80,7 @@ export const findOptimalBushingPlacement = (
       primarySlot: primaryPrimary,
       secondarySlot: primarySecondary,
       shouldClearExisting: true,
-      existingSlotsTolear: [...existingBushingSlots, primaryPrimary, primarySecondary]
+      existingSlotsToClear: [...existingBushingSlots, primaryPrimary, primarySecondary]
     };
   }
 


### PR DESCRIPTION
## Summary
- rename `existingSlotsTolear` to `existingSlotsToClear`
- update all uses in BOM builder and QTMS configuration editor

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d476f5b6883269938e4cf7c52f98f