### PR TITLE
Fix margin zero division

### DIFF
--- a/src/hooks/useQuotes.tsx
+++ b/src/hooks/useQuotes.tsx
@@ -207,8 +207,8 @@ export const useQuotes = () => {
 
       // Calculate new totals
       const newTotalPrice = newPrice * currentItem.quantity;
-      const newMargin = currentItem.unit_cost > 0 
-        ? ((newPrice - currentItem.unit_cost) / newPrice) * 100 
+      const newMargin = newPrice > 0
+        ? ((newPrice - currentItem.unit_cost) / newPrice) * 100
         : 0;
 
       // Create price adjustment history entry


### PR DESCRIPTION
## Summary
- avoid division by zero when computing margin in `updateBOMItemPrice`

## Testing
- `npm run lint` *(fails: 101 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685d476c55d88326af829dcc33f58681