### PR TITLE
Add cost fields for PD products

### DIFF
--- a/src/components/bom/PDProductSelector.tsx
+++ b/src/components/bom/PDProductSelector.tsx
@@ -27,6 +27,7 @@ const PDProductSelector = ({ onProductSelect, canSeePrices }: PDProductSelectorP
       type: 'QPDM',
       description: 'Advanced partial discharge monitoring system',
       price: 18500,
+      cost: 13500,
       enabled: true,
       partNumber: 'QPDM-001',
       productInfoUrl: 'https://qualitrol.com/qpdm'
@@ -41,6 +42,7 @@ const PDProductSelector = ({ onProductSelect, canSeePrices }: PDProductSelectorP
       type: 'Standard',
       description: 'Enhanced PD pattern analysis software',
       price: 1200,
+      cost: 800,
       enabled: false,
       partNumber: 'QPDM-SW'
     },
@@ -51,6 +53,7 @@ const PDProductSelector = ({ onProductSelect, canSeePrices }: PDProductSelectorP
       type: 'Standard',
       description: 'External PD sensor for transformer monitoring',
       price: 3200,
+      cost: 2200,
       enabled: false,
       partNumber: 'PDS-001'
     },
@@ -61,6 +64,7 @@ const PDProductSelector = ({ onProductSelect, canSeePrices }: PDProductSelectorP
       type: 'Standard',
       description: 'Ultra-high frequency PD detection sensor',
       price: 4800,
+      cost: 3300,
       enabled: false,
       partNumber: 'UHF-001'
     },
@@ -71,6 +75,7 @@ const PDProductSelector = ({ onProductSelect, canSeePrices }: PDProductSelectorP
       type: 'Standard',
       description: 'Portable PD calibration source',
       price: 850,
+      cost: 600,
       enabled: false,
       partNumber: 'PDC-001'
     },
@@ -81,6 +86,7 @@ const PDProductSelector = ({ onProductSelect, canSeePrices }: PDProductSelectorP
       type: 'Standard',
       description: 'Low-noise UHF signal amplifier',
       price: 680,
+      cost: 450,
       enabled: false,
       partNumber: 'UHFA-001'
     }


### PR DESCRIPTION
## Summary
- update QPDM product definition with `cost`
- add unit cost for PD sensors and accessories

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`
- `npm run lint` *(fails: unexpected any and import errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d7fa570608326b02595d7404f3c3a