### PR TITLE
Persist product catalog to Supabase

### DIFF
--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -67,8 +67,8 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
   };
 
   // CRUD Operations
-  const handleCreateLevel1Product = (productData: Omit<Level1Product, 'id'>) => {
-    const newProduct = productDataService.createLevel1Product(productData);
+  const handleCreateLevel1Product = async (productData: Omit<Level1Product, 'id'>) => {
+    const newProduct = await productDataService.createLevel1Product(productData);
     setDialogOpen(false);
     setEditingProduct(null);
     forceRefresh();
@@ -78,9 +78,9 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleUpdateLevel1Product = (productData: Omit<Level1Product, 'id'>) => {
+  const handleUpdateLevel1Product = async (productData: Omit<Level1Product, 'id'>) => {
     if (!editingProduct) return;
-    productDataService.updateLevel1Product(editingProduct.id, productData);
+    await productDataService.updateLevel1Product(editingProduct.id, productData);
     setDialogOpen(false);
     setEditingProduct(null);
     forceRefresh();
@@ -90,7 +90,7 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleDeleteLevel1Product = (productId: string) => {
+  const handleDeleteLevel1Product = async (productId: string) => {
     // Check for dependencies
     const dependentLevel2 = level2Products.filter(p => p.parentProductId === productId);
     if (dependentLevel2.length > 0) {
@@ -102,7 +102,7 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
       return;
     }
     
-    productDataService.deleteLevel1Product(productId);
+    await productDataService.deleteLevel1Product(productId);
     forceRefresh();
     toast({
       title: "Success",
@@ -110,8 +110,8 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleCreateLevel2Product = (productData: Omit<Level2Product, 'id'>) => {
-    const newProduct = productDataService.createLevel2Product(productData);
+  const handleCreateLevel2Product = async (productData: Omit<Level2Product, 'id'>) => {
+    const newProduct = await productDataService.createLevel2Product(productData);
     setDialogOpen(false);
     setEditingProduct(null);
     forceRefresh();
@@ -121,9 +121,9 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleUpdateLevel2Product = (productData: Omit<Level2Product, 'id'>) => {
+  const handleUpdateLevel2Product = async (productData: Omit<Level2Product, 'id'>) => {
     if (!editingProduct) return;
-    productDataService.updateLevel2Product(editingProduct.id, productData);
+    await productDataService.updateLevel2Product(editingProduct.id, productData);
     setDialogOpen(false);
     setEditingProduct(null);
     forceRefresh();
@@ -133,7 +133,7 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleDeleteLevel2Product = (productId: string) => {
+  const handleDeleteLevel2Product = async (productId: string) => {
     // Check for dependencies
     const dependentLevel3 = level3Products.filter(p => p.parentProductId === productId);
     if (dependentLevel3.length > 0) {
@@ -145,7 +145,7 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
       return;
     }
     
-    productDataService.deleteLevel2Product(productId);
+    await productDataService.deleteLevel2Product(productId);
     forceRefresh();
     toast({
       title: "Success",
@@ -153,8 +153,8 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleCreateLevel3Product = (productData: Omit<Level3Product, 'id'>) => {
-    const newProduct = productDataService.createLevel3Product(productData);
+  const handleCreateLevel3Product = async (productData: Omit<Level3Product, 'id'>) => {
+    const newProduct = await productDataService.createLevel3Product(productData);
     setDialogOpen(false);
     setEditingProduct(null);
     forceRefresh();
@@ -164,9 +164,9 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleUpdateLevel3Product = (productData: Omit<Level3Product, 'id'>) => {
+  const handleUpdateLevel3Product = async (productData: Omit<Level3Product, 'id'>) => {
     if (!editingProduct) return;
-    productDataService.updateLevel3Product(editingProduct.id, productData);
+    await productDataService.updateLevel3Product(editingProduct.id, productData);
     setDialogOpen(false);
     setEditingProduct(null);
     forceRefresh();
@@ -176,8 +176,8 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     });
   };
 
-  const handleDeleteLevel3Product = (productId: string) => {
-    productDataService.deleteLevel3Product(productId);
+  const handleDeleteLevel3Product = async (productId: string) => {
+    await productDataService.deleteLevel3Product(productId);
     forceRefresh();
     toast({
       title: "Success",


### PR DESCRIPTION
## Summary
- sync product data with Supabase on service init
- add async CRUD methods that read/write the `products` table
- update admin product management to use async CRUD functions

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d801218cc832681946e34aaf99dda