### PR TITLE
Read Supabase config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+The Supabase client expects the following variables to be available when running
+or building the app:
+
+- `SUPABASE_URL` – your Supabase project URL
+- `SUPABASE_ANON_KEY` – the public anonymous API key
+
+These can be placed in an `.env` file or set in your deployment environment.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/8d08ecff-3bea-40af-9fd0-71cf8c824485) and click on Share -> Publish.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,8 +1,8 @@
 
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = 'https://cwhmxpitwblqxgrvaigg.supabase.co'
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3aG14cGl0d2JscXhncnZhaWdnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA3MTc3MTIsImV4cCI6MjA2NjI5MzcxMn0.NaAtGg1Fpx1obdHK5rBGM5IzSWJea7lniuimr5ZyFGU'
+const supabaseUrl = import.meta.env.SUPABASE_URL as string
+const supabaseAnonKey = import.meta.env.SUPABASE_ANON_KEY as string
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,5 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  envPrefix: ["VITE_", "SUPABASE_"],
 }));


### PR DESCRIPTION
## Summary
- update the Supabase client to use `import.meta.env` variables
- expose `SUPABASE_` variables in Vite config
- document required environment variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685da7f469088326a30e65bd233b3360