### PR TITLE
Implement local product sync

### DIFF
--- a/src/components/admin/ProductSyncManager.tsx
+++ b/src/components/admin/ProductSyncManager.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { RefreshCw, Database, AlertCircle, CheckCircle } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/components/ui/use-toast";
+import { productDataService } from "@/services/productDataService";
 
 interface ProductSyncStats {
   level1Count: number;
@@ -41,6 +42,13 @@ const ProductSyncManager = () => {
       if (level1Result.error) throw level1Result.error;
       if (level2Result.error) throw level2Result.error;
       if (level3Result.error) throw level3Result.error;
+
+      // Persist fetched products to local storage
+      productDataService.replaceAllProducts(
+        level1Result.data || [],
+        level2Result.data || [],
+        level3Result.data || []
+      );
 
       // Update local state with fresh data
       setSyncStats({

--- a/src/services/productDataService.ts
+++ b/src/services/productDataService.ts
@@ -765,6 +765,21 @@ class ProductDataService {
     return level3.parentProductId === level2.id;
   }
 
+  /**
+   * Replace all existing product lists with freshly fetched data.
+   * This is useful when synchronizing from a remote source.
+   */
+  replaceAllProducts(
+    level1: Level1Product[],
+    level2: Level2Product[],
+    level3: Level3Product[]
+  ) {
+    this.level1Products = [...level1];
+    this.level2Products = [...level2];
+    this.level3Products = [...level3];
+    this.saveData();
+  }
+
   private initializeDefaultData() {
     // Initialize asset types if empty
     if (this.assetTypes.length === 0) {


### PR DESCRIPTION
## Summary
- store fetched products in `productDataService` during sync
- add helper to bulk replace products in local storage

## Testing
- `npm run lint` *(fails: unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_685db24341d08326a0597679a82a88ba