### PR TITLE
Use productDataService in selectors

### DIFF
--- a/src/components/bom/DGAProductSelector.tsx
+++ b/src/components/bom/DGAProductSelector.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -7,6 +7,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Level1Product, Level2Product } from "@/types/product";
+import { productDataService } from "@/services/productDataService";
 import { ExternalLink, Plus, CheckCircle2 } from "lucide-react";
 
 interface DGAProductSelectorProps {
@@ -18,81 +19,23 @@ const DGAProductSelector = ({ onProductSelect, canSeePrices }: DGAProductSelecto
   const [selectedProducts, setSelectedProducts] = useState<Set<string>>(new Set());
   const [selectedLevel2Options, setSelectedLevel2Options] = useState<Record<string, Level2Product[]>>({});
 
-  const dgaProducts: Level1Product[] = [
-    {
-      id: 'tm8',
-      name: 'TM8 - Advanced DGA Monitor',
-      type: 'TM8',
-      description: 'Multi-gas transformer monitoring system',
-      price: 24500,
-      enabled: true,
-      partNumber: 'TM8-001',
-      productInfoUrl: 'https://qualitrol.com/tm8'
-    },
-    {
-      id: 'tm3',
-      name: 'TM3 - Compact DGA Monitor',
-      type: 'TM3',
-      description: 'Essential dissolved gas analysis monitoring',
-      price: 18200,
-      enabled: true,
-      partNumber: 'TM3-001',
-      productInfoUrl: 'https://qualitrol.com/tm3'
-    },
-    {
-      id: 'tm1',
-      name: 'TM1 - Basic DGA Monitor',
-      type: 'TM1',
-      description: 'Single-gas hydrogen monitoring system',
-      price: 12800,
-      enabled: true,
-      partNumber: 'TM1-001',
-      productInfoUrl: 'https://qualitrol.com/tm1'
-    }
-  ];
+  const [dgaProducts, setDgaProducts] = useState<Level1Product[]>([]);
+  const [level2Options, setLevel2Options] = useState<Level2Product[]>([]);
 
-  const level2Options: Level2Product[] = [
-    {
-      id: 'calgas-bottle',
-      name: 'Calibration Gas Bottle',
-      parentProductId: '',
-      type: 'CalGas',
-      description: 'Precision calibration gas for DGA monitors',
-      price: 450,
-      enabled: false,
-      partNumber: 'CAL-GAS-001'
-    },
-    {
-      id: 'helium-bottle',
-      name: 'Helium Carrier Gas Bottle',
-      parentProductId: '',
-      type: 'Standard',
-      description: 'High-purity helium carrier gas supply',
-      price: 280,
-      enabled: false,
-      partNumber: 'HE-GAS-001'
-    },
-    {
-      id: 'moisture-sensor',
-      name: 'Moisture Sensor Add-on',
-      parentProductId: '',
-      type: 'Moisture',
-      description: 'Additional moisture detection capability',
-      price: 320,
-      enabled: false,
-      partNumber: 'MOIST-001'
-    },
-    {
-      id: '4-20ma-bridge',
-      name: '4-20mA Bridge Interface',
-      parentProductId: '',
-      type: 'Standard',
-      description: 'Analog output interface module',
-      price: 180,
-      enabled: false,
-      partNumber: '420MA-001'
-    }
-  ];
+  useEffect(() => {
+    const l1 = productDataService
+      .getLevel1Products()
+      .filter(
+        (p) =>
+          ['TM8', 'TM3', 'TM1'].includes(p.type) && p.enabled
+      );
+    setDgaProducts(l1);
+
+    const l2 = productDataService
+      .getLevel2Products()
+      .filter((p) => p.enabled && ['CalGas', 'Standard', 'Moisture'].includes(p.type));
+    setLevel2Options(l2);
+  }, []);
 
   const handleProductToggle = (productId: string) => {
     const newSelected = new Set(selectedProducts);

--- a/src/components/bom/PDProductSelector.tsx
+++ b/src/components/bom/PDProductSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -8,6 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Level1Product, Level2Product } from "@/types/product";
+import { productDataService } from "@/services/productDataService";
 import { ExternalLink, Plus, CheckCircle2 } from "lucide-react";
 
 interface PDProductSelectorProps {
@@ -20,71 +21,20 @@ const PDProductSelector = ({ onProductSelect, canSeePrices }: PDProductSelectorP
   const [standaloneLevel2Options, setStandaloneLevel2Options] = useState<Level2Product[]>([]);
   const [productConfigurations, setProductConfigurations] = useState<Record<string, Record<string, any>>>({});
 
-  const pdProducts: Level1Product[] = [
-    {
-      id: 'qpdm',
-      name: 'QPDM - Partial Discharge Monitor',
-      type: 'QPDM',
-      description: 'Advanced partial discharge monitoring system',
-      price: 18500,
-      enabled: true,
-      partNumber: 'QPDM-001',
-      productInfoUrl: 'https://qualitrol.com/qpdm'
-    }
-  ];
+  const [pdProducts, setPdProducts] = useState<Level1Product[]>([]);
+  const [level2Options, setLevel2Options] = useState<Level2Product[]>([]);
 
-  const level2Options: Level2Product[] = [
-    {
-      id: 'analysis-software',
-      name: 'Advanced Analysis Software',
-      parentProductId: '',
-      type: 'Standard',
-      description: 'Enhanced PD pattern analysis software',
-      price: 1200,
-      enabled: false,
-      partNumber: 'QPDM-SW'
-    },
-    {
-      id: 'pd-sensor',
-      name: 'PD Sensor Array',
-      parentProductId: '',
-      type: 'Standard',
-      description: 'External PD sensor for transformer monitoring',
-      price: 3200,
-      enabled: false,
-      partNumber: 'PDS-001'
-    },
-    {
-      id: 'uhf-sensor',
-      name: 'UHF PD Sensor',
-      parentProductId: '',
-      type: 'Standard',
-      description: 'Ultra-high frequency PD detection sensor',
-      price: 4800,
-      enabled: false,
-      partNumber: 'UHF-001'
-    },
-    {
-      id: 'calibrator',
-      name: 'PD Calibrator',
-      parentProductId: '',
-      type: 'Standard',
-      description: 'Portable PD calibration source',
-      price: 850,
-      enabled: false,
-      partNumber: 'PDC-001'
-    },
-    {
-      id: 'uhf-amplifier',
-      name: 'UHF Signal Amplifier',
-      parentProductId: '',
-      type: 'Standard',
-      description: 'Low-noise UHF signal amplifier',
-      price: 680,
-      enabled: false,
-      partNumber: 'UHFA-001'
-    }
-  ];
+  useEffect(() => {
+    const l1 = productDataService
+      .getLevel1Products()
+      .filter((p) => p.type === 'QPDM' && p.enabled);
+    setPdProducts(l1);
+
+    const l2 = productDataService
+      .getLevel2Products()
+      .filter((p) => p.enabled && p.parentProductId === 'qpdm');
+    setLevel2Options(l2);
+  }, []);
 
   const handleProductToggle = (productId: string) => {
     const newSelected = new Set(selectedProducts);


### PR DESCRIPTION
## Summary
- fetch DGA products and add-ons from productDataService
- fetch PD products and add-ons from productDataService

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dbfa7b6848326a2fb858f25eec919