### PR TITLE
Add default channel settings for cards

### DIFF
--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -21,6 +21,8 @@ import Level2OptionForm from "./product-forms/Level2OptionForm";
 import CardForm from "./product-forms/CardForm";
 import { useToast } from "@/hooks/use-toast";
 import { productDataService } from "@/services/productDataService";
+import AnalogDefaultsDialog from "./defaults/AnalogDefaultsDialog";
+import BushingDefaultsDialog from "./defaults/BushingDefaultsDialog";
 
 interface ProductManagementProps {
   user: User;
@@ -32,6 +34,8 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogType, setDialogType] = useState<'level1' | 'level2' | 'level3'>('level1');
   const [refreshKey, setRefreshKey] = useState(0);
+  const [settingsProduct, setSettingsProduct] = useState<Level3Product | null>(null);
+  const [settingsType, setSettingsType] = useState<'analog' | 'bushing' | null>(null);
   const { toast } = useToast();
 
   // Use productDataService instead of local state
@@ -195,6 +199,16 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
     setEditingProduct(null);
     setDialogType(type);
     setDialogOpen(true);
+  };
+
+  const openSettingsDialog = (product: Level3Product) => {
+    if (product.name.toLowerCase().includes('analog')) {
+      setSettingsType('analog');
+      setSettingsProduct(product);
+    } else if (product.name.toLowerCase().includes('bushing')) {
+      setSettingsType('bushing');
+      setSettingsProduct(product);
+    }
   };
 
   return (
@@ -512,17 +526,27 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
                         </div>
                       </div>
                       <div className="flex space-x-2">
-                        <Button 
-                          variant="ghost" 
-                          size="sm" 
+                        <Button
+                          variant="ghost"
+                          size="sm"
                           className="text-blue-400 hover:text-blue-300"
                           onClick={() => openEditDialog(product, 'level3')}
                         >
                           <Edit2 className="h-4 w-4" />
                         </Button>
-                        <Button 
-                          variant="ghost" 
-                          size="sm" 
+                        {(product.name.toLowerCase().includes('analog') || product.name.toLowerCase().includes('bushing')) && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-gray-400 hover:text-gray-200"
+                            onClick={() => openSettingsDialog(product)}
+                          >
+                            <Settings className="h-4 w-4" />
+                          </Button>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="sm"
                           className="text-red-400 hover:text-red-300"
                           onClick={() => handleDeleteLevel3Product(product.id)}
                         >
@@ -605,6 +629,26 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
           )}
         </DialogContent>
       </Dialog>
+
+      {settingsProduct && settingsType === 'analog' && (
+        <AnalogDefaultsDialog
+          product={settingsProduct}
+          onClose={() => {
+            setSettingsProduct(null);
+            setSettingsType(null);
+          }}
+        />
+      )}
+
+      {settingsProduct && settingsType === 'bushing' && (
+        <BushingDefaultsDialog
+          product={settingsProduct}
+          onClose={() => {
+            setSettingsProduct(null);
+            setSettingsType(null);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/admin/defaults/AnalogDefaultsDialog.tsx
+++ b/src/components/admin/defaults/AnalogDefaultsDialog.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Level3Product, ANALOG_SENSOR_TYPES, AnalogSensorType } from "@/types/product";
+
+interface AnalogDefaultsDialogProps {
+  product: Level3Product;
+  onClose: () => void;
+}
+
+const AnalogDefaultsDialog = ({ product, onClose }: AnalogDefaultsDialogProps) => {
+  const [channelConfigs, setChannelConfigs] = useState<Record<number, AnalogSensorType>>(() => {
+    const stored = localStorage.getItem(`analogDefaults_${product.id}`);
+    if (stored) return JSON.parse(stored);
+    const defaults: Record<number, AnalogSensorType> = {};
+    for (let i = 1; i <= 8; i++) {
+      defaults[i] = 'Pt100/RTD';
+    }
+    return defaults;
+  });
+
+  const handleChannelChange = (channel: number, sensorType: AnalogSensorType) => {
+    setChannelConfigs(prev => ({ ...prev, [channel]: sensorType }));
+  };
+
+  const handleSave = () => {
+    localStorage.setItem(`analogDefaults_${product.id}`, JSON.stringify(channelConfigs));
+    onClose();
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent className="bg-gray-900 border-gray-800 max-w-3xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-white">Default Analog Channels - {product.name}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {[1,2,3,4,5,6,7,8].map((channel) => (
+              <div key={channel} className="space-y-2">
+                <Label className="text-white font-medium">Channel {channel}</Label>
+                <Select value={channelConfigs[channel]} onValueChange={(value: AnalogSensorType) => handleChannelChange(channel, value)}>
+                  <SelectTrigger className="bg-gray-700 border-gray-600 text-white">
+                    <SelectValue placeholder="Select sensor type" />
+                  </SelectTrigger>
+                  <SelectContent className="bg-gray-700 border-gray-600 max-h-60">
+                    {ANALOG_SENSOR_TYPES.map(sensor => (
+                      <SelectItem key={sensor} value={sensor} className="text-white hover:bg-gray-600 focus:bg-gray-600">
+                        {sensor}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ))}
+          </div>
+          <div className="flex justify-end space-x-2 pt-4 border-t border-gray-700">
+            <Button variant="outline" onClick={onClose} className="border-gray-600 text-black bg-white hover:bg-gray-100">
+              Cancel
+            </Button>
+            <Button className="bg-red-600 hover:bg-red-700 text-white" onClick={handleSave}>
+              Save Defaults
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AnalogDefaultsDialog;

--- a/src/components/admin/defaults/BushingDefaultsDialog.tsx
+++ b/src/components/admin/defaults/BushingDefaultsDialog.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Level3Product } from "@/types/product";
+
+const BUSHING_TAP_MODELS = ['Standard','High Accuracy','High Frequency','Custom'];
+
+interface BushingDefaultsDialogProps {
+  product: Level3Product;
+  onClose: () => void;
+}
+
+const BushingDefaultsDialog = ({ product, onClose }: BushingDefaultsDialogProps) => {
+  const stored = localStorage.getItem(`bushingDefaults_${product.id}`);
+  const parsed = stored ? JSON.parse(stored) as {numberOfBushings: number; configs: Record<number,string>} : null;
+  const [numberOfBushings, setNumberOfBushings] = useState<number>(parsed?.numberOfBushings || 1);
+  const [configs, setConfigs] = useState<Record<number,string>>(() => parsed?.configs || {1: 'Standard'});
+
+  const handleNumberChange = (value: number) => {
+    if (value < 1 || value > 6) return;
+    setNumberOfBushings(value);
+    setConfigs(prev => {
+      const updated: Record<number,string> = { ...prev };
+      for (let i = 1; i <= value; i++) {
+        if (!updated[i]) updated[i] = 'Standard';
+      }
+      Object.keys(updated).forEach(key => { if (parseInt(key) > value) delete updated[key]; });
+      return updated;
+    });
+  };
+
+  const handleConfigChange = (num: number, model: string) => {
+    setConfigs(prev => ({ ...prev, [num]: model }));
+  };
+
+  const handleSave = () => {
+    localStorage.setItem(`bushingDefaults_${product.id}`, JSON.stringify({ numberOfBushings, configs }));
+    onClose();
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent className="bg-gray-900 border-gray-800 max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-white">Default Bushing Taps - {product.name}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="num-bushings" className="text-white font-medium">Number of Bushings</Label>
+            <Input id="num-bushings" type="number" min="1" max="6" value={numberOfBushings} onChange={e => handleNumberChange(Number(e.target.value))} className="bg-gray-700 border-gray-600 text-white" />
+          </div>
+          {[...Array(numberOfBushings)].map((_, index) => (
+            <div key={index} className="space-y-2">
+              <Label className="text-white font-medium">Bushing {index + 1} Tap Model</Label>
+              <Select value={configs[index+1]} onValueChange={val => handleConfigChange(index+1, val)}>
+                <SelectTrigger className="bg-gray-700 border-gray-600 text-white">
+                  <SelectValue placeholder="Select tap model" />
+                </SelectTrigger>
+                <SelectContent className="bg-gray-700 border-gray-600">
+                  {BUSHING_TAP_MODELS.map(model => (
+                    <SelectItem key={model} value={model} className="text-white hover:bg-gray-600 focus:bg-gray-600">{model}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ))}
+          <div className="flex justify-end space-x-2 pt-4 border-t border-gray-700">
+            <Button variant="outline" onClick={onClose} className="border-gray-600 text-black bg-white hover:bg-gray-100">Cancel</Button>
+            <Button className="bg-red-600 hover:bg-red-700 text-white" onClick={handleSave}>Save Defaults</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default BushingDefaultsDialog;

--- a/src/components/bom/AnalogCardConfigurator.tsx
+++ b/src/components/bom/AnalogCardConfigurator.tsx
@@ -21,24 +21,27 @@ interface AnalogCardConfiguratorProps {
 
 const AnalogCardConfigurator = ({ bomItem, onSave, onClose }: AnalogCardConfiguratorProps) => {
   const [channelConfigs, setChannelConfigs] = useState<Record<number, AnalogSensorType>>(() => {
-    // Initialize with existing configurations or default to first sensor type
     const configs: Record<number, AnalogSensorType> = {};
-    
+
     if (bomItem.level3Customizations) {
       bomItem.level3Customizations.forEach((config, index) => {
         if (config.name && ANALOG_SENSOR_TYPES.includes(config.name as AnalogSensorType)) {
           configs[index + 1] = config.name as AnalogSensorType;
         }
       });
+    } else {
+      const stored = localStorage.getItem(`analogDefaults_${bomItem.product.id}`);
+      if (stored) {
+        Object.assign(configs, JSON.parse(stored));
+      }
     }
-    
-    // Fill in any missing channels with default
+
     for (let i = 1; i <= 8; i++) {
       if (!configs[i]) {
         configs[i] = 'Pt100/RTD';
       }
     }
-    
+
     return configs;
   });
 

--- a/src/components/bom/BushingCardConfigurator.tsx
+++ b/src/components/bom/BushingCardConfigurator.tsx
@@ -26,10 +26,10 @@ const BUSHING_TAP_MODELS = [
 ];
 
 const BushingCardConfigurator = ({ bomItem, onSave, onClose }: BushingCardConfiguratorProps) => {
-  const [numberOfBushings, setNumberOfBushings] = useState<number>(1);
-  const [bushingConfigurations, setBushingConfigurations] = useState<Record<number, string>>({
-    1: 'Standard'
-  });
+  const stored = localStorage.getItem(`bushingDefaults_${bomItem.product.id}`);
+  const parsed = stored ? JSON.parse(stored) as {numberOfBushings: number; configs: Record<number, string>} : null;
+  const [numberOfBushings, setNumberOfBushings] = useState<number>(parsed?.numberOfBushings || 1);
+  const [bushingConfigurations, setBushingConfigurations] = useState<Record<number, string>>(() => parsed?.configs || { 1: 'Standard' });
 
   const handleNumberOfBushingsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);


### PR DESCRIPTION
## Summary
- add dialogs for setting default analog channel sensors and bushing tap models
- show gear icon in Level 3 management for configuring defaults
- load stored defaults when configuring cards in BOM builder

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dbfaa6a848326a77c5c8b6b275a64