### PR TITLE
Add delete buttons for sensor config items

### DIFF
--- a/src/components/admin/SensorConfigManagement.tsx
+++ b/src/components/admin/SensorConfigManagement.tsx
@@ -37,6 +37,15 @@ const SensorConfigManagement = () => {
     refresh();
   };
 
+  const handleDeleteAnalog = async (id: string) => {
+    await productDataService.deleteAnalogSensorType(id);
+    if (editingAnalogId === id) {
+      setAnalogForm({ name: "", description: "" });
+      setEditingAnalogId(null);
+    }
+    refresh();
+  };
+
   const handleEditAnalog = (id: string) => {
     const item = analogTypes.find(a => a.id === id);
     if (item) {
@@ -52,6 +61,15 @@ const SensorConfigManagement = () => {
       await productDataService.createBushingTapModel(bushingForm);
     }
     resetForms();
+    refresh();
+  };
+
+  const handleDeleteBushing = async (id: string) => {
+    await productDataService.deleteBushingTapModel(id);
+    if (editingBushingId === id) {
+      setBushingForm({ name: "" });
+      setEditingBushingId(null);
+    }
     refresh();
   };
 
@@ -79,6 +97,9 @@ const SensorConfigManagement = () => {
               </div>
               <Button variant="ghost" size="sm" onClick={() => handleEditAnalog(type.id)} className="text-blue-400">
                 Edit
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => handleDeleteAnalog(type.id)} className="text-red-400">
+                Delete
               </Button>
             </div>
           ))}
@@ -109,6 +130,9 @@ const SensorConfigManagement = () => {
               <span className="flex-1 text-white text-sm">{model.name}</span>
               <Button variant="ghost" size="sm" onClick={() => handleEditBushing(model.id)} className="text-blue-400">
                 Edit
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => handleDeleteBushing(model.id)} className="text-red-400">
+                Delete
               </Button>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- enable deleting analog sensor types and bushing tap models
- refresh list and clear edit form when deleting edited item

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dc8a02ca88326a6a1bf1f07b05c25