### PR TITLE
Add product defaults tab

### DIFF
--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -4,15 +4,16 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { 
-  Plus, 
-  Edit2, 
-  Trash2, 
-  Package, 
-  Layers, 
+import {
+  Plus,
+  Edit2,
+  Trash2,
+  Package,
+  Layers,
   Settings,
   ExternalLink,
-  ChevronRight
+  ChevronRight,
+  SlidersHorizontal
 } from "lucide-react";
 import { User } from "@/types/auth";
 import { Level1Product, Level2Product, Level3Product } from "@/types/product";
@@ -212,6 +213,7 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
       setSettingsType('bushing');
       setSettingsProduct(product);
     }
+    setActiveTab('defaults');
   };
 
   return (
@@ -227,7 +229,7 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-        <TabsList className="grid w-full grid-cols-3 bg-gray-800">
+        <TabsList className="grid w-full grid-cols-4 bg-gray-800">
           <TabsTrigger 
             value="level1" 
             className="text-white data-[state=active]:bg-red-600 data-[state=active]:text-white"
@@ -242,12 +244,19 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
             <Layers className="h-4 w-4 mr-2" />
             Level 2: Variants ({level2Products.length})
           </TabsTrigger>
-          <TabsTrigger 
-            value="level3" 
+          <TabsTrigger
+            value="level3"
             className="text-white data-[state=active]:bg-red-600 data-[state=active]:text-white"
           >
             <Settings className="h-4 w-4 mr-2" />
             Level 3: Components ({level3Products.length})
+          </TabsTrigger>
+          <TabsTrigger
+            value="defaults"
+            className="text-white data-[state=active]:bg-red-600 data-[state=active]:text-white"
+          >
+            <SlidersHorizontal className="h-4 w-4 mr-2" />
+            Defaults
           </TabsTrigger>
         </TabsList>
 
@@ -594,6 +603,29 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
             })}
           </div>
         </TabsContent>
+        <TabsContent value="defaults" className="space-y-6">
+          {settingsProduct && settingsType === 'analog' && (
+            <AnalogDefaultsDialog
+              product={settingsProduct}
+              onClose={() => {
+                setSettingsProduct(null);
+                setSettingsType(null);
+              }}
+            />
+          )}
+          {settingsProduct && settingsType === 'bushing' && (
+            <BushingDefaultsDialog
+              product={settingsProduct}
+              onClose={() => {
+                setSettingsProduct(null);
+                setSettingsType(null);
+              }}
+            />
+          )}
+          {!settingsProduct && (
+            <p className="text-gray-400">Select a component from the Components tab to configure defaults.</p>
+          )}
+        </TabsContent>
       </Tabs>
 
       {/* Edit/Create Dialog */}
@@ -634,25 +666,6 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
         </DialogContent>
       </Dialog>
 
-      {settingsProduct && settingsType === 'analog' && (
-        <AnalogDefaultsDialog
-          product={settingsProduct}
-          onClose={() => {
-            setSettingsProduct(null);
-            setSettingsType(null);
-          }}
-        />
-      )}
-
-      {settingsProduct && settingsType === 'bushing' && (
-        <BushingDefaultsDialog
-          product={settingsProduct}
-          onClose={() => {
-            setSettingsProduct(null);
-            setSettingsType(null);
-          }}
-        />
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `SlidersHorizontal` icon import
- add `Defaults` tab to `ProductManagement`
- switch to the new tab when opening product settings dialogs
- render customization dialogs in the new tab

## Testing
- `npm run lint` *(fails: numerous lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_685dc8a1ceb88326ba1827f13307f5eb