### PR TITLE
Clean configurator components

### DIFF
--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -22,11 +22,9 @@ import Level2OptionForm from "./product-forms/Level2OptionForm";
 import CardForm from "./product-forms/CardForm";
 import { useToast } from "@/hooks/use-toast";
 import { productDataService } from "@/services/productDataService";
-codex/adicionar-ícone-de-motor-nas-telas-de-gerenciamento
 import AnalogDefaultsDialog from "./defaults/AnalogDefaultsDialog";
 import BushingDefaultsDialog from "./defaults/BushingDefaultsDialog";
 import SensorConfigManagement from "./SensorConfigManagement";
-main
 
 interface ProductManagementProps {
   user: User;
@@ -252,19 +250,18 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
             Level 3: Components ({level3Products.length})
           </TabsTrigger>
           <TabsTrigger
-          codex/add-tab-for-product-customization-defaults
             value="defaults"
             className="text-white data-[state=active]:bg-red-600 data-[state=active]:text-white"
           >
             <SlidersHorizontal className="h-4 w-4 mr-2" />
             Defaults
-
+          </TabsTrigger>
+          <TabsTrigger
             value="sensor-config"
             className="text-white data-[state=active]:bg-red-600 data-[state=active]:text-white"
           >
             <Settings className="h-4 w-4 mr-2" />
             Sensor Config
-        main
           </TabsTrigger>
         </TabsList>
 
@@ -610,7 +607,7 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
             })}
           </div>
         </TabsContent>
-       codex/add-tab-for-product-customization-defaults
+
         <TabsContent value="defaults" className="space-y-6">
           {settingsProduct && settingsType === 'analog' && (
             <AnalogDefaultsDialog
@@ -630,14 +627,13 @@ const ProductManagement = ({ user }: ProductManagementProps) => {
               }}
             />
           )}
-          {!settingsProduct && (
-            <p className="text-gray-400">Select a component from the Components tab to configure defaults.</p>
-          )}
-
+            {!settingsProduct && (
+              <p className="text-gray-400">Select a component from the Components tab to configure defaults.</p>
+            )}
+          </TabsContent>
 
         <TabsContent value="sensor-config" className="space-y-6">
           <SensorConfigManagement />
-      main
         </TabsContent>
       </Tabs>
 

--- a/src/components/bom/AnalogCardConfigurator.tsx
+++ b/src/components/bom/AnalogCardConfigurator.tsx
@@ -21,17 +21,10 @@ interface AnalogCardConfiguratorProps {
 }
 
 const AnalogCardConfigurator = ({ bomItem, onSave, onClose }: AnalogCardConfiguratorProps) => {
-codex/adicionar-ícone-de-motor-nas-telas-de-gerenciamento
-  const [channelConfigs, setChannelConfigs] = useState<Record<number, AnalogSensorType>>(() => {
-    const configs: Record<number, AnalogSensorType> = {};
-
-
   const sensorOptions = productDataService.getAnalogSensorTypes();
   const [channelConfigs, setChannelConfigs] = useState<Record<number, string>>(() => {
     // Initialize with existing configurations or default to first sensor type
     const configs: Record<number, string> = {};
-    
-main
     if (bomItem.level3Customizations) {
       bomItem.level3Customizations.forEach((config, index) => {
         if (config.name && sensorOptions.some(s => s.name === config.name)) {
@@ -45,10 +38,7 @@ main
       }
     }
 
-codex/adicionar-ícone-de-motor-nas-telas-de-gerenciamento
-
-    // Fill in any missing channels with default
-main
+  // Fill in any missing channels with default
     for (let i = 1; i <= 8; i++) {
       if (!configs[i]) {
         configs[i] = sensorOptions[0]?.name || '';

--- a/src/components/bom/BushingCardConfigurator.tsx
+++ b/src/components/bom/BushingCardConfigurator.tsx
@@ -21,18 +21,14 @@ interface BushingCardConfiguratorProps {
 
 
 const BushingCardConfigurator = ({ bomItem, onSave, onClose }: BushingCardConfiguratorProps) => {
-codex/adicionar-ícone-de-motor-nas-telas-de-gerenciamento
   const stored = localStorage.getItem(`bushingDefaults_${bomItem.product.id}`);
-  const parsed = stored ? JSON.parse(stored) as {numberOfBushings: number; configs: Record<number, string>} : null;
-  const [numberOfBushings, setNumberOfBushings] = useState<number>(parsed?.numberOfBushings || 1);
-  const [bushingConfigurations, setBushingConfigurations] = useState<Record<number, string>>(() => parsed?.configs || { 1: 'Standard' });
+  const parsed = stored ? (JSON.parse(stored) as { numberOfBushings: number; configs: Record<number, string> }) : null;
 
   const tapModels = productDataService.getBushingTapModels();
-  const [numberOfBushings, setNumberOfBushings] = useState<number>(1);
-  const [bushingConfigurations, setBushingConfigurations] = useState<Record<number, string>>({
-    1: tapModels[0]?.name || 'Standard'
-  });
-main
+  const [numberOfBushings, setNumberOfBushings] = useState<number>(parsed?.numberOfBushings || 1);
+  const [bushingConfigurations, setBushingConfigurations] = useState<Record<number, string>>(
+    () => parsed?.configs || { 1: tapModels[0]?.name || 'Standard' }
+  );
 
   const handleNumberOfBushingsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);


### PR DESCRIPTION
## Summary
- remove stray text in configuration dialogs
- fix duplicate state variables
- tidy product management tabs

## Testing
- `npm run lint` *(fails: unexpected any usage)*
- `npm run build` *(fails: missing export ANALOG_SENSOR_TYPES)*

------
https://chatgpt.com/codex/tasks/task_e_685dd8aebf10832681714a5dc2b4e819