### PR TITLE
Fix QuoteTable admin display

### DIFF
--- a/src/components/admin/quote-approval/QuoteTable.tsx
+++ b/src/components/admin/quote-approval/QuoteTable.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -17,15 +16,9 @@ interface QuoteTableProps {
   isAdmin?: boolean;
 }
 
-codex/extend-quotetable-with-cost-and-margin-columns
 const QuoteTable = ({ quotes, loading, onQuoteSelect, isAdmin = false }: QuoteTableProps) => {
-
-const QuoteTable = ({ quotes, loading, onQuoteSelect }: QuoteTableProps) => {
   const [expandedId, setExpandedId] = useState<string | null>(null);
-qnwid3-codex/implement-search-bar-with-filters
 
-main
-main
   if (loading) {
     return (
       <Card className="bg-gray-900 border-gray-800">
@@ -46,33 +39,33 @@ main
     );
   }
 
-  const getStatusColor = (status: Quote['status']) => {
+  const getStatusColor = (status: Quote["status"]) => {
     switch (status) {
-      case 'pending_approval':
-        return 'bg-yellow-600 text-white';
-      case 'approved':
-        return 'bg-green-600 text-white';
-      case 'rejected':
-        return 'bg-red-600 text-white';
-      case 'draft':
-        return 'bg-gray-600 text-white';
+      case "pending_approval":
+        return "bg-yellow-600 text-white";
+      case "approved":
+        return "bg-green-600 text-white";
+      case "rejected":
+        return "bg-red-600 text-white";
+      case "draft":
+        return "bg-gray-600 text-white";
       default:
-        return 'bg-gray-600 text-white';
+        return "bg-gray-600 text-white";
     }
   };
 
-  const getPriorityColor = (priority: Quote['priority']) => {
+  const getPriorityColor = (priority: Quote["priority"]) => {
     switch (priority) {
-      case 'Urgent':
-        return 'bg-red-500 text-white';
-      case 'High':
-        return 'bg-orange-500 text-white';
-      case 'Medium':
-        return 'bg-yellow-500 text-white';
-      case 'Low':
-        return 'bg-green-500 text-white';
+      case "Urgent":
+        return "bg-red-500 text-white";
+      case "High":
+        return "bg-orange-500 text-white";
+      case "Medium":
+        return "bg-yellow-500 text-white";
+      case "Low":
+        return "bg-green-500 text-white";
       default:
-        return 'bg-gray-500 text-white';
+        return "bg-gray-500 text-white";
     }
   };
 
@@ -82,7 +75,6 @@ main
         <CardTitle className="text-white">Quotes ({quotes.length})</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-      qnwid3-codex/implement-search-bar-with-filters
         {quotes.map((quote) => {
           const expanded = expandedId === quote.id;
           return (
@@ -94,11 +86,21 @@ main
                 <div>
                   <h4 className="text-white font-medium">{quote.id}</h4>
                   <p className="text-gray-400 text-sm">{quote.customer_name}</p>
+                  {isAdmin && (
+                    <p className="text-gray-500 text-xs">
+                      Cost: {quote.currency} {quote.total_cost.toLocaleString()}
+                    </p>
+                  )}
                 </div>
-                <div className="flex items-center space-x-2">
+                <div className="text-right">
                   <p className="text-white font-medium">
                     {quote.currency} {quote.discounted_value.toLocaleString()}
                   </p>
+                  {isAdmin && (
+                    <p className="text-gray-400 text-xs">
+                      {quote.discounted_margin.toFixed(1)}% margin
+                    </p>
+                  )}
                   <Button
                     variant="ghost"
                     size="icon"
@@ -113,94 +115,11 @@ main
                 </div>
               </div>
 
-
-      codex/extend-quotetable-with-cost-and-margin-columns
-        {quotes.map((quote) => (
-          <div
-            key={quote.id}
-            className="p-4 bg-gray-800 rounded-lg border border-gray-700 hover:border-red-500 transition-colors"
-          >
-            <div className="flex justify-between items-start mb-3">
-              <div>
-                <h4 className="text-white font-medium">{quote.id}</h4>
-                <p className="text-gray-400 text-sm">{quote.customer_name}</p>
-                <p className="text-gray-500 text-xs">Oracle: {quote.oracle_customer_id}</p>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Badge className={getStatusColor(quote.status)}>
-                  {quote.status.replace('_', ' ').toUpperCase()}
-                </Badge>
-                <Badge className={getPriorityColor(quote.priority)}>
-                  {quote.priority}
-                </Badge>
-                {quote.discounted_margin < 25 && (
-                  <AlertTriangle className="h-4 w-4 text-yellow-400" />
-                )}
-              </div>
-            </div>
-            
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm mb-3">
-              <div>
-                <span className="text-gray-400">Original Value:</span>
-                <span className="text-white ml-2">{quote.currency} {quote.original_quote_value.toLocaleString()}</span>
-              </div>
-              <div>
-                <span className="text-gray-400">After Discount:</span>
-                <span className="text-white ml-2">{quote.currency} {quote.discounted_value.toLocaleString()}</span>
-              </div>
-              {isAdmin && (
-                <>
-                  <div>
-                    <span className="text-gray-400">Total Cost:</span>
-                    <span className="text-white ml-2">{quote.currency} {quote.total_cost.toLocaleString()}</span>
-                  </div>
-                  <div>
-                    <span className="text-gray-400">Gross Margin:</span>
-                    <span className="text-white ml-2">{quote.discounted_margin.toFixed(1)}%</span>
-                  </div>
-                </>
-              )}
-              <div>
-                <span className="text-gray-400">BOM Items:</span>
-                <span className="text-white ml-2">{quote.bom_items?.length || 0}</span>
-
-        {quotes.map((quote) => {
-          const expanded = expandedId === quote.id;
-          return (
-            <div
-              key={quote.id}
-              className="p-4 bg-gray-800 rounded-lg border border-gray-700 hover:border-red-500 transition-colors"
-            >
-              <div className="flex justify-between items-start mb-2">
-                <div>
-                  <h4 className="text-white font-medium">{quote.id}</h4>
-                  <p className="text-gray-400 text-sm">{quote.customer_name}</p>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <p className="text-white font-medium">
-                    {quote.currency} {quote.discounted_value.toLocaleString()}
-                  </p>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setExpandedId(expanded ? null : quote.id)}
-                  >
-                    {expanded ? (
-                      <ChevronUp className="h-4 w-4" />
-                    ) : (
-                      <ChevronDown className="h-4 w-4" />
-                    )}
-                  </Button>
-                </div>
-              main
-              </div>
-
-              main
               {expanded && (
                 <>
                   <div className="flex items-center space-x-2 mb-3">
                     <Badge className={getStatusColor(quote.status)}>
-                      {quote.status.replace('_', ' ').toUpperCase()}
+                      {quote.status.replace("_", " ").toUpperCase()}
                     </Badge>
                     <Badge className={getPriorityColor(quote.priority)}>
                       {quote.priority}
@@ -221,18 +140,40 @@ main
                     </div>
                     <div>
                       <span className="text-gray-400">Original Value:</span>
-                      <span className="text-white ml-2">{quote.currency} {quote.original_quote_value.toLocaleString()}</span>
+                      <span className="text-white ml-2">
+                        {quote.currency} {quote.original_quote_value.toLocaleString()}
+                      </span>
                     </div>
                     <div>
-                      <span className="text-gray-400">Margin:</span>
-                      <span className="text-white ml-2">{quote.discounted_margin.toFixed(1)}%</span>
+                      <span className="text-gray-400">After Discount:</span>
+                      <span className="text-white ml-2">
+                        {quote.currency} {quote.discounted_value.toLocaleString()}
+                      </span>
                     </div>
+                    {isAdmin && (
+                      <>
+                        <div>
+                          <span className="text-gray-400">Total Cost:</span>
+                          <span className="text-white ml-2">
+                            {quote.currency} {quote.total_cost.toLocaleString()}
+                          </span>
+                        </div>
+                        <div>
+                          <span className="text-gray-400">Gross Margin:</span>
+                          <span className="text-white ml-2">
+                            {quote.discounted_margin.toFixed(1)}%
+                          </span>
+                        </div>
+                      </>
+                    )}
                   </div>
 
                   {quote.discount_justification && (
                     <div className="mb-3">
                       <p className="text-gray-400 text-xs mb-1">Discount Justification:</p>
-                      <p className="text-gray-300 text-sm bg-gray-700 p-2 rounded">{quote.discount_justification}</p>
+                      <p className="text-gray-300 text-sm bg-gray-700 p-2 rounded">
+                        {quote.discount_justification}
+                      </p>
                     </div>
                   )}
 


### PR DESCRIPTION
## Summary
- clean up `QuoteTable.tsx`
- keep `isAdmin` prop and show cost/margin in collapsed and expanded rows

## Testing
- `npm run lint` *(fails: unexpected any in other files)*
- `npx cypress run` *(fails: npm 403 when downloading cypress)*

------
https://chatgpt.com/codex/tasks/task_e_685de476f42c832687df3e806a6d1b7e