### PR TITLE
Update dev server port docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,15 @@ npm i
 
 ## Running the Development Server
 
-Launch the Vite dev server on <http://localhost:8080>:
+Launch the Vite dev server with:
 
 ```sh
 npm run dev
 ```
+
+By default, Vite listens on <http://localhost:5173>. This project overrides the
+port to `8080` in [`vite.config.ts`](vite.config.ts) under `server.port`. Adjust
+that value if you'd like to run the server on a different port.
 
 ## Running Supabase Migrations
 


### PR DESCRIPTION
## Summary
- note that Vite defaults to port 5173
- mention that this project overrides to 8080

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ff2efdf1c832685ad61e948c1a840