### PR TITLE
Fix sensor type exports

### DIFF
--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -7,10 +7,13 @@ export * from './product/type-guards';
 export * from './product/part-number-utils';
 
 // Explicit re-exports for commonly used types including Level 4
-export type { 
-  AnalogSensorType, 
-  AnalogSensorOption, 
+export type {
+  AnalogSensorType,
+  AnalogSensorOption,
   BushingTapModelOption,
+} from './product/sensor-config';
+
+export type {
   Level4Product,
   Level4ConfigurationOption
 } from './product/interfaces';

--- a/src/types/product/index.ts
+++ b/src/types/product/index.ts
@@ -11,10 +11,13 @@ export * from './sensor-config';
 export * from './part-number-utils';
 
 // Explicit re-exports to ensure availability including Level 4
-export type { 
-  AnalogSensorType, 
-  AnalogSensorOption, 
+export type {
+  AnalogSensorType,
+  AnalogSensorOption,
   BushingTapModelOption,
+} from './sensor-config';
+
+export type {
   Level4Product,
   Level4ConfigurationOption
 } from './interfaces';


### PR DESCRIPTION
## Summary
- export `AnalogSensorType`, `AnalogSensorOption`, and `BushingTapModelOption` from `sensor-config`
- keep `Level4Product` & `Level4ConfigurationOption` from `interfaces`

## Testing
- `npm run lint` *(fails: Unexpected any & require imports)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3e6f5708326b5e3c8438623d758