### PR TITLE
Add optional fields to Level4Product

### DIFF
--- a/src/types/product/interfaces.ts
+++ b/src/types/product/interfaces.ts
@@ -77,12 +77,14 @@ export interface Level4Product {
   id: string;
   name: string;
   parentProductId: string; // Links to Level3Product
+  type?: string;
   description: string;
   configurationType: 'dropdown' | 'multiline';
   price: number;
   cost?: number;
   enabled: boolean;
   options: Level4ConfigurationOption[];
+  partNumber?: string;
 }
 
 export interface Level4ConfigurationOption {


### PR DESCRIPTION
## Summary
- include `type?` and `partNumber?` in `Level4Product` interface for union compatibility

## Testing
- `npm run lint` *(fails: unexpected any, etc.)*
- `npm run build` *(fails: build error about missing export)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3e710888326b2a32a053e04fca5