### PR TITLE
Map BOM items to include product details

### DIFF
--- a/src/components/admin/quote-approval/QuoteDetails.tsx
+++ b/src/components/admin/quote-approval/QuoteDetails.tsx
@@ -301,7 +301,7 @@ const QuoteDetails = ({
                       )}
                     </div>
                     <div className="flex space-x-1">
-                      {item.product.type === 'QTMS' && item.configuration && (
+                      {item.product?.type === 'QTMS' && item.configuration && (
                         <Button
                           size="sm"
                           variant="ghost"


### PR DESCRIPTION
## Summary
- enrich BOM items in EnhancedQuoteApprovalDashboard with a product object
- use optional chaining when accessing product type in QuoteDetails

## Testing
- `npm run lint` *(fails: 88 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6860401b33c883268bbe4fdcda6e35c2