### PR TITLE
Add product editing management

### DIFF
--- a/src/components/admin/ProductManagement.tsx
+++ b/src/components/admin/ProductManagement.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, AlertCircle } from "lucide-react";
+import { RefreshCw, AlertCircle, Edit, Trash2 } from "lucide-react";
 import Level1ProductForm from "./product-forms/Level1ProductForm";
 import ChassisForm from "./product-forms/ChassisForm";
 import CardForm from "./product-forms/CardForm";
@@ -12,6 +12,7 @@ import { Level4ConfigurationManager } from "./Level4ConfigurationManager";
 import { Level1Product, Level2Product, Level3Product, Level4Product } from "@/types/product";
 import { productDataService } from "@/services/productDataService";
 import { useToast } from "@/hooks/use-toast";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export const ProductManagement = () => {
   const { toast } = useToast();
@@ -19,6 +20,11 @@ export const ProductManagement = () => {
   const [error, setError] = useState<string | null>(null);
   const [level1Products, setLevel1Products] = useState<Level1Product[]>([]);
   const [level2Products, setLevel2Products] = useState<Level2Product[]>([]);
+  const [level3Products, setLevel3Products] = useState<Level3Product[]>([]);
+
+  const [editingLevel1, setEditingLevel1] = useState<Level1Product | null>(null);
+  const [editingLevel2, setEditingLevel2] = useState<Level2Product | null>(null);
+  const [editingLevel3, setEditingLevel3] = useState<Level3Product | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
   useEffect(() => {
@@ -36,18 +42,21 @@ export const ProductManagement = () => {
       await productDataService.initialize();
       
       // Load all product data
-      const [l1Products, l2Products] = await Promise.all([
+      const [l1Products, l2Products, l3Products] = await Promise.all([
         productDataService.getLevel1Products(),
-        productDataService.getLevel2Products()
+        productDataService.getLevel2Products(),
+        productDataService.getLevel3Products()
       ]);
       
-      console.log('ProductManagement: Data loaded successfully:', { 
-        l1Count: l1Products.length, 
-        l2Count: l2Products.length 
+      console.log('ProductManagement: Data loaded successfully:', {
+        l1Count: l1Products.length,
+        l2Count: l2Products.length,
+        l3Count: l3Products.length
       });
-      
+
       setLevel1Products(l1Products);
       setLevel2Products(l2Products);
+      setLevel3Products(l3Products);
       
     } catch (err) {
       console.error('ProductManagement: Error initializing data:', err);
@@ -57,8 +66,10 @@ export const ProductManagement = () => {
       try {
         const l1Sync = productDataService.getLevel1ProductsSync();
         const l2Sync = productDataService.getLevel2ProductsSync();
+        const l3Sync = productDataService.getLevel3ProductsSync();
         setLevel1Products(l1Sync);
         setLevel2Products(l2Sync);
+        setLevel3Products(l3Sync);
         console.log('ProductManagement: Fallback to sync data successful');
       } catch (syncError) {
         console.error('ProductManagement: Fallback also failed:', syncError);
@@ -92,13 +103,14 @@ export const ProductManagement = () => {
     setRefreshTrigger(prev => prev + 1);
   };
 
-  const handleLevel1Save = async (productData: Omit<Level1Product, 'id'> | Level1Product) => {
+  const handleLevel1Save = async (productData: Omit<Level1Product, 'id'>) => {
     try {
       console.log('ProductManagement: Saving Level 1 product:', productData);
-      
-      if ('id' in productData) {
-        await productDataService.updateLevel1Product(productData.id, productData);
+
+      if (editingLevel1) {
+        await productDataService.updateLevel1Product(editingLevel1.id, productData);
         toast({ title: "Success", description: "Level 1 product updated successfully" });
+        setEditingLevel1(null);
       } else {
         await productDataService.createLevel1Product(productData);
         toast({ title: "Success", description: "Level 1 product created successfully" });
@@ -114,13 +126,14 @@ export const ProductManagement = () => {
     }
   };
 
-  const handleLevel2Save = async (productData: Omit<Level2Product, 'id'> | Level2Product) => {
+  const handleLevel2Save = async (productData: Omit<Level2Product, 'id'>) => {
     try {
       console.log('ProductManagement: Saving Level 2 product:', productData);
-      
-      if ('id' in productData) {
-        // Update method needs to be implemented in service
+
+      if (editingLevel2) {
+        await productDataService.updateLevel2Product(editingLevel2.id, productData);
         toast({ title: "Success", description: "Level 2 product updated successfully" });
+        setEditingLevel2(null);
       } else {
         await productDataService.createLevel2Product(productData);
         toast({ title: "Success", description: "Level 2 product created successfully" });
@@ -136,13 +149,14 @@ export const ProductManagement = () => {
     }
   };
 
-  const handleLevel3Save = async (productData: Omit<Level3Product, 'id'> | Level3Product) => {
+  const handleLevel3Save = async (productData: Omit<Level3Product, 'id'>) => {
     try {
       console.log('ProductManagement: Saving Level 3 product:', productData);
-      
-      if ('id' in productData) {
-        // Update method needs to be implemented in service
+
+      if (editingLevel3) {
+        await productDataService.updateLevel3Product(editingLevel3.id, productData);
         toast({ title: "Success", description: "Level 3 product updated successfully" });
+        setEditingLevel3(null);
       } else {
         await productDataService.createLevel3Product(productData);
         toast({ title: "Success", description: "Level 3 product created successfully" });
@@ -156,6 +170,42 @@ export const ProductManagement = () => {
         description: "Failed to save Level 3 product", 
         variant: "destructive" 
       });
+    }
+  };
+
+  const handleDeleteLevel1 = async (id: string) => {
+    if (!confirm('Delete this Level 1 product?')) return;
+    try {
+      await productDataService.deleteLevel1Product(id);
+      toast({ title: 'Deleted', description: 'Level 1 product removed' });
+      refreshProductData();
+    } catch (error) {
+      console.error('Error deleting Level 1 product:', error);
+      toast({ title: 'Error', description: 'Failed to delete Level 1 product', variant: 'destructive' });
+    }
+  };
+
+  const handleDeleteLevel2 = async (id: string) => {
+    if (!confirm('Delete this Level 2 product?')) return;
+    try {
+      await productDataService.deleteLevel2Product(id);
+      toast({ title: 'Deleted', description: 'Level 2 product removed' });
+      refreshProductData();
+    } catch (error) {
+      console.error('Error deleting Level 2 product:', error);
+      toast({ title: 'Error', description: 'Failed to delete Level 2 product', variant: 'destructive' });
+    }
+  };
+
+  const handleDeleteLevel3 = async (id: string) => {
+    if (!confirm('Delete this Level 3 product?')) return;
+    try {
+      await productDataService.deleteLevel3Product(id);
+      toast({ title: 'Deleted', description: 'Level 3 product removed' });
+      refreshProductData();
+    } catch (error) {
+      console.error('Error deleting Level 3 product:', error);
+      toast({ title: 'Error', description: 'Failed to delete Level 3 product', variant: 'destructive' });
     }
   };
 
@@ -239,6 +289,7 @@ export const ProductManagement = () => {
           <div className="mt-2 text-sm text-gray-600 flex items-center gap-4">
             <span>Level 1: {level1Products.length} products</span>
             <span>Level 2: {level2Products.length} products</span>
+            <span>Level 3: {level3Products.length} products</span>
             <Button 
               onClick={refreshProductData} 
               variant="ghost" 
@@ -272,8 +323,43 @@ export const ProductManagement = () => {
                 Main product categories (QTMS, TM8, TM3, etc.). These are the top-level products in your hierarchy.
               </CardDescription>
             </CardHeader>
-            <CardContent>
-              <Level1ProductForm onSubmit={handleLevel1Save} />
+            <CardContent className="space-y-6">
+              <Level1ProductForm onSubmit={handleLevel1Save} initialData={editingLevel1 ?? undefined} />
+              {editingLevel1 && (
+                <Button variant="outline" size="sm" onClick={() => setEditingLevel1(null)}>
+                  Cancel Edit
+                </Button>
+              )}
+
+              {level1Products.length > 0 && (
+                <Table className="mt-4">
+                  <TableHeader>
+                    <TableRow className="border-gray-800">
+                      <TableHead className="text-gray-300">Name</TableHead>
+                      <TableHead className="text-gray-300">Type</TableHead>
+                      <TableHead className="text-gray-300">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {level1Products.map(p => (
+                      <TableRow key={p.id} className="border-gray-800">
+                        <TableCell className="text-white">{p.name}</TableCell>
+                        <TableCell className="text-gray-300">{p.type}</TableCell>
+                        <TableCell>
+                          <div className="flex space-x-2">
+                            <Button size="sm" variant="ghost" onClick={() => setEditingLevel1(p)}>
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button size="sm" variant="ghost" onClick={() => handleDeleteLevel1(p.id)}>
+                              <Trash2 className="h-4 w-4 text-red-500" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
@@ -291,17 +377,54 @@ export const ProductManagement = () => {
                 )}
               </CardDescription>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-6">
               {level1Products.length > 0 ? (
-                <ChassisForm 
-                  onSubmit={handleLevel2Save} 
+                <ChassisForm
+                  onSubmit={handleLevel2Save}
                   level1Products={level1Products}
+                  initialData={editingLevel2 ?? undefined}
                 />
               ) : (
                 <div className="text-center py-8 text-gray-500">
                   <p>No Level 1 products available.</p>
                   <p>Create Level 1 products first to enable Level 2 product creation.</p>
                 </div>
+              )}
+
+              {editingLevel2 && (
+                <Button variant="outline" size="sm" onClick={() => setEditingLevel2(null)}>
+                  Cancel Edit
+                </Button>
+              )}
+
+              {level2Products.length > 0 && (
+                <Table className="mt-4">
+                  <TableHeader>
+                    <TableRow className="border-gray-800">
+                      <TableHead className="text-gray-300">Name</TableHead>
+                      <TableHead className="text-gray-300">Type</TableHead>
+                      <TableHead className="text-gray-300">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {level2Products.map(p => (
+                      <TableRow key={p.id} className="border-gray-800">
+                        <TableCell className="text-white">{p.name}</TableCell>
+                        <TableCell className="text-gray-300">{p.type}</TableCell>
+                        <TableCell>
+                          <div className="flex space-x-2">
+                            <Button size="sm" variant="ghost" onClick={() => setEditingLevel2(p)}>
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button size="sm" variant="ghost" onClick={() => handleDeleteLevel2(p.id)}>
+                              <Trash2 className="h-4 w-4 text-red-500" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
               )}
             </CardContent>
           </Card>
@@ -320,14 +443,15 @@ export const ProductManagement = () => {
                 )}
               </CardDescription>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-6">
               <div className="grid gap-6">
                 <div>
                   <h4 className="text-lg font-semibold mb-4">Cards & Components</h4>
                   {level2Products.length > 0 ? (
-                    <CardForm 
+                    <CardForm
                       onSubmit={handleLevel3Save}
                       level2Products={level2Products}
+                      initialData={editingLevel3 ?? undefined}
                     />
                   ) : (
                     <div className="text-center py-4 text-gray-500">
@@ -338,9 +462,10 @@ export const ProductManagement = () => {
                 <div>
                   <h4 className="text-lg font-semibold mb-4">Product Options</h4>
                   {level1Products.length > 0 ? (
-                    <Level2OptionForm 
+                    <Level2OptionForm
                       onSubmit={handleLevel3Save}
                       level1Products={level1Products}
+                      initialData={editingLevel3 ?? undefined}
                     />
                   ) : (
                     <div className="text-center py-4 text-gray-500">
@@ -349,6 +474,42 @@ export const ProductManagement = () => {
                   )}
                 </div>
               </div>
+
+              {editingLevel3 && (
+                <Button variant="outline" size="sm" onClick={() => setEditingLevel3(null)}>
+                  Cancel Edit
+                </Button>
+              )}
+
+              {level3Products.length > 0 && (
+                <Table className="mt-4">
+                  <TableHeader>
+                    <TableRow className="border-gray-800">
+                      <TableHead className="text-gray-300">Name</TableHead>
+                      <TableHead className="text-gray-300">Type</TableHead>
+                      <TableHead className="text-gray-300">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {level3Products.map(p => (
+                      <TableRow key={p.id} className="border-gray-800">
+                        <TableCell className="text-white">{p.name}</TableCell>
+                        <TableCell className="text-gray-300">{p.type}</TableCell>
+                        <TableCell>
+                          <div className="flex space-x-2">
+                            <Button size="sm" variant="ghost" onClick={() => setEditingLevel3(p)}>
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button size="sm" variant="ghost" onClick={() => handleDeleteLevel3(p.id)}>
+                              <Trash2 className="h-4 w-4 text-red-500" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
             </CardContent>
           </Card>
         </TabsContent>

--- a/src/services/productDataService.ts
+++ b/src/services/productDataService.ts
@@ -548,6 +548,45 @@ class ProductDataService {
     return newProduct;
   }
 
+  async updateLevel2Product(id: string, updates: Partial<Omit<Level2Product, 'id'>>): Promise<Level2Product | null> {
+    await this.initialize();
+    const index = this.level2Products.findIndex(product => product.id === id);
+    if (index !== -1) {
+      this.level2Products[index] = { ...this.level2Products[index], ...updates };
+      this.saveToLocalStorage();
+
+      try {
+        await supabase.from('products')
+          .update({
+            name: this.level2Products[index].name,
+            description: this.level2Products[index].description,
+            subcategory: this.level2Products[index].type,
+            price: this.level2Products[index].price,
+            cost: this.level2Products[index].cost ?? null,
+            is_active: this.level2Products[index].enabled
+          })
+          .eq('id', id);
+      } catch (error) {
+        console.error('Failed to update level2 product', error);
+      }
+
+      return this.level2Products[index];
+    }
+    return null;
+  }
+
+  async deleteLevel2Product(id: string): Promise<void> {
+    await this.initialize();
+    this.level2Products = this.level2Products.filter(product => product.id !== id);
+    this.saveToLocalStorage();
+
+    try {
+      await supabase.from('products').delete().eq('id', id);
+    } catch (error) {
+      console.error('Failed to delete level2 product', error);
+    }
+  }
+
   // Level 3 and Level 4 methods
   async createLevel3Product(product: Omit<Level3Product, 'id'>): Promise<Level3Product> {
     await this.initialize();
@@ -574,6 +613,45 @@ class ProductDataService {
     }
 
     return newProduct;
+  }
+
+  async updateLevel3Product(id: string, updates: Partial<Omit<Level3Product, 'id'>>): Promise<Level3Product | null> {
+    await this.initialize();
+    const index = this.level3Products.findIndex(product => product.id === id);
+    if (index !== -1) {
+      this.level3Products[index] = { ...this.level3Products[index], ...updates };
+      this.saveToLocalStorage();
+
+      try {
+        await supabase.from('products')
+          .update({
+            name: this.level3Products[index].name,
+            description: this.level3Products[index].description,
+            subcategory: this.level3Products[index].type,
+            price: this.level3Products[index].price,
+            cost: this.level3Products[index].cost ?? null,
+            is_active: this.level3Products[index].enabled ?? true
+          })
+          .eq('id', id);
+      } catch (error) {
+        console.error('Failed to update level3 product', error);
+      }
+
+      return this.level3Products[index];
+    }
+    return null;
+  }
+
+  async deleteLevel3Product(id: string): Promise<void> {
+    await this.initialize();
+    this.level3Products = this.level3Products.filter(product => product.id !== id);
+    this.saveToLocalStorage();
+
+    try {
+      await supabase.from('products').delete().eq('id', id);
+    } catch (error) {
+      console.error('Failed to delete level3 product', error);
+    }
   }
 
   async createLevel4Product(product: Omit<Level4Product, 'id'>): Promise<Level4Product> {


### PR DESCRIPTION
## Summary
- enable editing and deletion of Level 1-3 products
- show existing product lists in admin Product Management
- keep BOM builder product data service functionality intact

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686475332c34832693a8a8505a5e300f