### PR TITLE
Ensure product service is initialized before loading Level 1 products

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -87,7 +87,17 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices }: BOMBuilderProps) => {
   useEffect(() => {
     const loadLevel1Products = async () => {
       try {
-        const products = await productDataService.getLevel1Products();
+        // Ensure the product data service is fully initialized before
+        // attempting to retrieve products. This guarantees that any
+        // database values are loaded instead of stale defaults.
+        await productDataService.initialize();
+
+        let products = await productDataService.getLevel1Products();
+        setLevel1Products(products.filter(p => p.enabled));
+
+        // Refresh once more after initialization to ensure the latest
+        // database values are reflected in state.
+        products = await productDataService.getLevel1Products();
         setLevel1Products(products.filter(p => p.enabled));
       } catch (error) {
         console.error('Error loading Level 1 products:', error);


### PR DESCRIPTION
## Summary
- initialize productDataService before fetching Level 1 products in BOMBuilder
- refresh products after initialization to capture database changes

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686479eab56c8326b2b28ebce01ac8df