### PR TITLE
Restrict dev tools to dev mode

### DIFF
--- a/src/services/productDataService.ts
+++ b/src/services/productDataService.ts
@@ -724,8 +724,8 @@ class ProductDataService {
 
 export const productDataService = new ProductDataService();
 
-// Expose for debugging
-if (typeof window !== 'undefined') {
+// Expose for debugging in development only
+if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
   (window as any).productDataService = productDataService;
   (window as any).clearProductData = () => productDataService.clearCorruptedData();
   (window as any).getProductDebugInfo = () => productDataService.getDebugInfo();


### PR DESCRIPTION
## Summary
- only expose `productDataService` helpers in development

## Testing
- `npm run lint` *(fails: unexpected any, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686479eb470c8326b7244d5aa500d73f