### PR TITLE
Improve logout cleanup

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -304,6 +304,21 @@ function useProvideAuth(): AuthContextType {
     try {
       await logSecurityEvent('logout_initiated');
       const { error } = await supabase.auth.signOut();
+
+      if (error) {
+        console.error('[useAuth] Supabase signOut error:', error);
+      } else {
+        console.log('[useAuth] Supabase signOut successful');
+        // Clear auth state immediately
+        setUser(null);
+        setSession(null);
+        try {
+          localStorage.removeItem('supabase.auth.token');
+        } catch (storageErr) {
+          console.warn('[useAuth] Failed to clear local storage:', storageErr);
+        }
+      }
+
       return { error };
     } catch (err) {
       console.error('[useAuth] Sign out error:', err);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,6 +24,12 @@ const Index = () => {
       } else {
         console.log('Logout successful');
       }
+      // Log the auth state immediately after sign-out
+      console.log('Auth state after logout call:', {
+        user,
+        loading,
+        timestamp: new Date().toISOString(),
+      });
     } catch (err) {
       console.error('Unexpected logout error:', err);
     }


### PR DESCRIPTION
## Summary
- ensure `useAuth.signOut` clears auth state and local storage
- log auth state after logout in Index page

## Testing
- `npm run lint` *(fails: 148 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686916ba2ed48326a8c72b8af0551417