### PR TITLE
Add chart for monthly quote volume

### DIFF
--- a/src/components/dashboard/QuoteAnalyticsDashboard.tsx
+++ b/src/components/dashboard/QuoteAnalyticsDashboard.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { TrendingUp, TrendingDown, BarChart3, DollarSign, FileText, CheckCircle, XCircle, Clock } from "lucide-react";
 import { QuoteAnalytics, formatCurrency } from "@/utils/quoteAnalytics";
+import QuoteVolumeChart from "./QuoteVolumeChart";
 
 interface QuoteAnalyticsDashboardProps {
   analytics: QuoteAnalytics;
@@ -96,6 +97,9 @@ const QuoteAnalyticsDashboard = ({ analytics, isAdmin = false }: QuoteAnalyticsD
           color="text-red-500"
         />
       </div>
+
+      {/* Quote Volume Trend Chart */}
+      <QuoteVolumeChart />
 
       {/* Quoted Value */}
       <Card className="bg-gray-900 border-gray-800">

--- a/src/components/dashboard/QuoteVolumeChart.tsx
+++ b/src/components/dashboard/QuoteVolumeChart.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { supabase } from "@/integrations/supabase/client";
+import * as Recharts from "recharts";
+
+interface AnalyticsRow {
+  month: string;
+  status: string;
+  quote_count: number;
+}
+
+interface ChartData {
+  month: string;
+  approved: number;
+  rejected: number;
+  underReview: number;
+}
+
+const QuoteVolumeChart = () => {
+  const [data, setData] = useState<ChartData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const { data: rows, error } = await supabase
+          .from("quote_analytics")
+          .select("month, status, quote_count")
+          .in("status", ["approved", "rejected", "under-review"])
+          .order("month", { ascending: true });
+
+        if (error) {
+          console.error("Error fetching quote analytics", error);
+          setLoading(false);
+          return;
+        }
+
+        const grouped: Record<string, ChartData> = {};
+        (rows as AnalyticsRow[]).forEach((row) => {
+          const key = row.month;
+          if (!grouped[key]) {
+            grouped[key] = { month: key, approved: 0, rejected: 0, underReview: 0 };
+          }
+          if (row.status === "approved") grouped[key].approved = row.quote_count;
+          else if (row.status === "rejected") grouped[key].rejected = row.quote_count;
+          else if (row.status === "under-review") grouped[key].underReview = row.quote_count;
+        });
+
+        const sorted = Object.values(grouped).sort(
+          (a, b) => new Date(a.month).getTime() - new Date(b.month).getTime()
+        );
+        setData(sorted);
+      } catch (err) {
+        console.error("Failed to load analytics", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const monthFormatter = (value: string) => {
+    const date = new Date(value);
+    return `${date.toLocaleString("default", { month: "short" })} ${date.getFullYear()}`;
+  };
+
+  return (
+    <Card className="bg-gray-900 border-gray-800">
+      <CardHeader>
+        <CardTitle className="text-white">Quote Volume Trends</CardTitle>
+        <CardDescription className="text-gray-400">
+          Monthly count of quotes by status
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="text-center text-gray-400">Loading chart...</div>
+        ) : (
+          <ChartContainer
+            config={{
+              approved: { label: "Approved", color: "#10b981" },
+              rejected: { label: "Rejected", color: "#ef4444" },
+              underReview: { label: "Under Review", color: "#facc15" },
+            }}
+          >
+            <Recharts.LineChart data={data}>
+              <Recharts.CartesianGrid strokeDasharray="3 3" />
+              <Recharts.XAxis dataKey="month" tickFormatter={monthFormatter} />
+              <Recharts.YAxis allowDecimals={false} />
+              <Recharts.Line
+                type="monotone"
+                dataKey="approved"
+                stroke="var(--color-approved)"
+              />
+              <Recharts.Line
+                type="monotone"
+                dataKey="rejected"
+                stroke="var(--color-rejected)"
+              />
+              <Recharts.Line
+                type="monotone"
+                dataKey="underReview"
+                stroke="var(--color-underReview)"
+              />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <ChartLegend verticalAlign="bottom" content={<ChartLegendContent />} />
+            </Recharts.LineChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default QuoteVolumeChart;


### PR DESCRIPTION
## Summary
- fetch monthly quote volume from `quote_analytics`
- display new chart in analytics dashboard

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686916cc42f88326bda1259839cba6dd