### PR TITLE
Handle missing Supabase env vars

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "@/hooks/useAuth";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { supabaseConfigValid } from "@/integrations/supabase/client";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -33,6 +34,24 @@ const App = () => {
     version: '2.0.0',
     environment: import.meta.env.MODE
   });
+
+  if (!supabaseConfigValid) {
+    console.error('Supabase configuration missing. Check README setup steps.');
+    return (
+      <div className="min-h-screen bg-black flex items-center justify-center">
+        <div className="text-white text-center max-w-md p-6">
+          <h2 className="text-2xl font-bold mb-4 text-red-400">
+            Supabase Configuration Required
+          </h2>
+          <p className="text-gray-300 mb-6">
+            Missing <code>VITE_SUPABASE_URL</code> or{' '}
+            <code>VITE_SUPABASE_ANON_KEY</code>. See the README for setup
+            instructions.
+          </p>
+        </div>
+      </div>
+    );
+  }
   
   return (
     <ErrorBoundary fallback={

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,8 +1,12 @@
 
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+// Capture environment variables
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
+
+// Flag indicating whether Supabase configuration is present
+export const supabaseConfigValid = Boolean(supabaseUrl && supabaseAnonKey)
 
 console.log('Supabase client initialization:', {
   url: supabaseUrl ? 'configured' : 'missing',
@@ -63,4 +67,6 @@ async function testSupabaseConnection(): Promise<void> {
   }
 }
 
-void testSupabaseConnection();
+if (supabaseConfigValid) {
+  void testSupabaseConnection();
+}


### PR DESCRIPTION
## Summary
- flag invalid Supabase config in `src/integrations/supabase/client.ts`
- halt app startup in `App.tsx` when env vars are missing

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686aece5a0948326812e79905bc27b4d