### PR TITLE
Fix environment setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm install
 ### 3. Environment Configuration
 ```bash
 # Copy the environment template
-cp .env
+cp .env.example .env
 
 # Edit .env and add your Supabase credentials
 VITE_SUPABASE_URL=https://cwhmxpitwblqxgrvaigg.supabase.co


### PR DESCRIPTION
## Summary
- clarify setup instructions to copy `.env.example` to `.env`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686af118cc588326b53f94368560d6e9