### PR TITLE
Handle missing Level4 configs and extend profile fetch timeout

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,27 +1,27 @@
-import { createContext, useContext, useEffect, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
-import { supabase } from '@/integrations/supabase/client';
-import { User, AuthError, Role } from '@/types/auth';
-import { toast } from '@/hooks/use-toast';
+import { createContext, useContext, useEffect, useState } from "react";
+import { createClient } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
+import { User, AuthError, Role } from "@/types/auth";
+import { toast } from "@/hooks/use-toast";
 
 // Helper function to map database role to app role
 const mapDatabaseRoleToAppRole = (dbRole: string): Role => {
   switch (dbRole) {
-    case 'level1':
-    case 'LEVEL_1':
-      return 'LEVEL_1';
-    case 'level2':
-    case 'LEVEL_2':
-      return 'LEVEL_2';
-    case 'admin':
-    case 'ADMIN':
-      return 'ADMIN';
-    case 'LEVEL_3':
-      return 'LEVEL_3';
-    case 'FINANCE':
-      return 'FINANCE';
+    case "level1":
+    case "LEVEL_1":
+      return "LEVEL_1";
+    case "level2":
+    case "LEVEL_2":
+      return "LEVEL_2";
+    case "admin":
+    case "ADMIN":
+      return "ADMIN";
+    case "LEVEL_3":
+      return "LEVEL_3";
+    case "FINANCE":
+      return "FINANCE";
     default:
-      return 'LEVEL_1';
+      return "LEVEL_1";
   }
 };
 
@@ -40,7 +40,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 };
@@ -52,93 +52,101 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [error, setError] = useState<AuthError | null>(null);
 
   useEffect(() => {
-    console.log('[AuthProvider] Initializing auth state...');
-    
+    console.log("[AuthProvider] Initializing auth state...");
+
     // Force loading to false after maximum timeout
     const maxLoadingTimeout = setTimeout(() => {
-      console.warn('[AuthProvider] Maximum loading timeout reached, forcing loading to false');
+      console.warn(
+        "[AuthProvider] Maximum loading timeout reached, forcing loading to false",
+      );
       setLoading(false);
     }, 8000);
 
     // Setup auth state listener first
     const { data: listener } = supabase.auth.onAuthStateChange(
       async (event, session) => {
-        console.log('[AuthProvider] Auth state change:', {
+        console.log("[AuthProvider] Auth state change:", {
           event,
           hasSession: !!session,
           userId: session?.user?.id,
           userEmail: session?.user?.email,
           userRole: user?.role,
-          loading: loading
+          loading: loading,
         });
-        
+
         clearTimeout(maxLoadingTimeout);
         setSession(session);
         setError(null);
-        
+
         if (session?.user) {
-          console.log('[AuthProvider] User session found, fetching profile...', {
-            userId: session.user.id,
-            userEmail: session.user.email
-          });
+          console.log(
+            "[AuthProvider] User session found, fetching profile...",
+            {
+              userId: session.user.id,
+              userEmail: session.user.email,
+            },
+          );
           try {
-            await fetchProfile(session.user.id, 3000);
-            
+            await fetchProfile(session.user.id, 8000);
+
             // Log session events
-            if (event === 'SIGNED_IN') {
-              await logUserSession(session.user.id, 'login');
-            } else if (event === 'TOKEN_REFRESHED') {
-              await logUserSession(session.user.id, 'session_refresh');
+            if (event === "SIGNED_IN") {
+              await logUserSession(session.user.id, "login");
+            } else if (event === "TOKEN_REFRESHED") {
+              await logUserSession(session.user.id, "session_refresh");
             }
           } catch (error) {
-            console.error('[AuthProvider] Error fetching profile in auth state change:', error);
+            console.error(
+              "[AuthProvider] Error fetching profile in auth state change:",
+              error,
+            );
             setUser(null);
           } finally {
             setLoading(false);
           }
         } else {
-          console.log('[AuthProvider] No user session, clearing user state');
-          if (event === 'SIGNED_OUT' && user) {
-            await logUserSession(user.id, 'logout');
+          console.log("[AuthProvider] No user session, clearing user state");
+          if (event === "SIGNED_OUT" && user) {
+            await logUserSession(user.id, "logout");
           }
           setUser(null);
           setLoading(false);
         }
-      }
+      },
     );
 
     // Get initial session with timeout
     const getInitialSession = async () => {
       try {
-        console.log('[AuthProvider] Getting initial session...');
+        console.log("[AuthProvider] Getting initial session...");
         const sessionPromise = supabase.auth.getSession();
         const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Session fetch timeout')), 5000);
+          setTimeout(() => reject(new Error("Session fetch timeout")), 5000);
         });
 
-        const { data: { session }, error } = await Promise.race([
-          sessionPromise,
-          timeoutPromise
-        ]);
+        const {
+          data: { session },
+          error,
+        } = await Promise.race([sessionPromise, timeoutPromise]);
 
         if (error) {
-          console.error('[AuthProvider] Initial session error:', {
+          console.error("[AuthProvider] Initial session error:", {
             errorCode: error.code,
-            errorMessage: error.message
+            errorMessage: error.message,
           });
           setError({
-            code: error.code || 'SESSION_ERROR',
+            code: error.code || "SESSION_ERROR",
             message: error.message,
-            type: 'session'
+            type: "session",
           });
           setLoading(false);
           return;
         }
 
-        console.log('[AuthProvider] Initial session check:', {
+        console.log("[AuthProvider] Initial session check:", {
           hasSession: !!session,
           userId: session?.user?.id,
-          userEmail: session?.user?.email
+          userEmail: session?.user?.email,
         });
         setSession(session);
 
@@ -146,11 +154,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           await fetchProfile(session.user.id, 3000);
         }
       } catch (err) {
-        console.error('[AuthProvider] Initial session timeout or error:', err);
+        console.error("[AuthProvider] Initial session timeout or error:", err);
         setError({
-          code: 'SESSION_ERROR',
-          message: 'Failed to initialize session',
-          type: 'session'
+          code: "SESSION_ERROR",
+          message: "Failed to initialize session",
+          type: "session",
         });
       } finally {
         clearTimeout(maxLoadingTimeout);
@@ -170,45 +178,48 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       setLoading(true);
       setError(null);
-      
-      console.log('[AuthProvider] Attempting sign in with:', {
+
+      console.log("[AuthProvider] Attempting sign in with:", {
         email: email,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
 
-      const { error: authError, data: { session } } = await supabase.auth.signInWithPassword({
+      const {
+        error: authError,
+        data: { session },
+      } = await supabase.auth.signInWithPassword({
         email,
-        password
+        password,
       });
 
       if (authError) {
-        console.error('[AuthProvider] Sign in error:', {
+        console.error("[AuthProvider] Sign in error:", {
           errorCode: authError.code,
-          errorMessage: authError.message
+          errorMessage: authError.message,
         });
         setError({
-          code: authError.code || 'AUTH_ERROR',
+          code: authError.code || "AUTH_ERROR",
           message: authError.message,
-          type: 'auth'
+          type: "auth",
         });
         return { error: authError };
       }
 
-      console.log('[AuthProvider] Sign in successful:', {
+      console.log("[AuthProvider] Sign in successful:", {
         userId: session?.user?.id,
-        userEmail: session?.user?.email
+        userEmail: session?.user?.email,
       });
 
       // Wait for auth state change to update session and user
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       return { error: null };
     } catch (err) {
-      console.error('[AuthProvider] Sign in unexpected error:', err);
+      console.error("[AuthProvider] Sign in unexpected error:", err);
       setError({
-        code: 'AUTH_ERROR',
-        message: 'An unexpected error occurred during sign in',
-        type: 'auth'
+        code: "AUTH_ERROR",
+        message: "An unexpected error occurred during sign in",
+        type: "auth",
       });
       return { error: err };
     } finally {
@@ -220,15 +231,15 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       setLoading(true);
       setError(null);
-      
+
       const { error: authError } = await supabase.auth.signOut();
 
       if (authError) {
-        console.error('[AuthProvider] Sign out error:', authError);
+        console.error("[AuthProvider] Sign out error:", authError);
         setError({
-          code: authError.code || 'AUTH_ERROR',
+          code: authError.code || "AUTH_ERROR",
           message: authError.message,
-          type: 'auth'
+          type: "auth",
         });
         return;
       }
@@ -236,11 +247,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setUser(null);
       setSession(null);
     } catch (err) {
-      console.error('[AuthProvider] Sign out unexpected error:', err);
+      console.error("[AuthProvider] Sign out unexpected error:", err);
       setError({
-        code: 'AUTH_ERROR',
-        message: 'An unexpected error occurred during sign out',
-        type: 'auth'
+        code: "AUTH_ERROR",
+        message: "An unexpected error occurred during sign out",
+        type: "auth",
       });
     } finally {
       setLoading(false);
@@ -251,124 +262,137 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       setLoading(true);
       setError(null);
-      
+
       const { error: authError } = await supabase.auth.refreshSession();
 
       if (authError) {
-        console.error('[AuthProvider] Session refresh error:', authError);
+        console.error("[AuthProvider] Session refresh error:", authError);
         setError({
-          code: authError.code || 'SESSION_ERROR',
+          code: authError.code || "SESSION_ERROR",
           message: authError.message,
-          type: 'session'
+          type: "session",
         });
         return;
       }
     } catch (err) {
-      console.error('[AuthProvider] Session refresh unexpected error:', err);
+      console.error("[AuthProvider] Session refresh unexpected error:", err);
       setError({
-        code: 'SESSION_ERROR',
-        message: 'An unexpected error occurred during session refresh',
-        type: 'session'
+        code: "SESSION_ERROR",
+        message: "An unexpected error occurred during session refresh",
+        type: "session",
       });
     } finally {
       setLoading(false);
     }
   };
 
-  const logUserSession = async (userId: string, event: 'login' | 'logout' | 'session_refresh') => {
+  const logUserSession = async (
+    userId: string,
+    event: "login" | "logout" | "session_refresh",
+  ) => {
     try {
-      const { error } = await supabase
-        .from('user_sessions')
-        .insert({
-          user_id: userId,
-          event,
-          session_token: `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-          ip_address: 'unknown',
-          user_agent: navigator.userAgent,
-          device_info: {
-            platform: navigator.platform,
-            language: navigator.language,
-            screen_resolution: `${screen.width}x${screen.height}`
-          },
-          location: {}
-        });
+      const { error } = await supabase.from("user_sessions").insert({
+        user_id: userId,
+        event,
+        session_token: `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+        ip_address: "unknown",
+        user_agent: navigator.userAgent,
+        device_info: {
+          platform: navigator.platform,
+          language: navigator.language,
+          screen_resolution: `${screen.width}x${screen.height}`,
+        },
+        location: {},
+      });
 
       if (error) {
-        console.error('Error logging user session:', error);
+        console.error("Error logging user session:", error);
         setError({
-          code: error.code || 'SESSION_LOG_ERROR',
-          message: error.message || 'Failed to log user session',
-          type: 'session'
+          code: error.code || "SESSION_LOG_ERROR",
+          message: error.message || "Failed to log user session",
+          type: "session",
         });
       }
     } catch (err) {
-      console.error('Error logging user session:', err);
+      console.error("Error logging user session:", err);
       setError({
-        code: 'SESSION_LOG_ERROR',
-        message: 'Failed to log user session',
-        type: 'session'
+        code: "SESSION_LOG_ERROR",
+        message: "Failed to log user session",
+        type: "session",
       });
     }
   };
 
-  const fetchProfile = async (uid: string, timeoutMs: number = 3000): Promise<void> => {
-    console.log('[AuthProvider] fetchProfile start for:', uid);
-    
+  const fetchProfile = async (
+    uid: string,
+    timeoutMs: number = 8000,
+  ): Promise<void> => {
+    console.log("[AuthProvider] fetchProfile start for:", uid);
+
     try {
       // First try to get the profile
       const profilePromise = supabase
-        .from('profiles')
-        .select('*')
-        .eq('id', uid)
+        .from("profiles")
+        .select("*")
+        .eq("id", uid)
         .single();
 
       const { data, error } = await Promise.race([
         profilePromise,
-        new Promise<never>((_, reject) => 
-          setTimeout(() => reject(new Error('Profile fetch timeout')), timeoutMs)
-        )
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Profile fetch timeout")),
+            timeoutMs,
+          ),
+        ),
       ]);
 
       if (error) {
-        if (error.code === 'PGRST116') {
-          console.log('[AuthProvider] No profile found, creating new profile for user:', uid);
+        if (error.code === "PGRST116") {
+          console.log(
+            "[AuthProvider] No profile found, creating new profile for user:",
+            uid,
+          );
           const { error: createError } = await supabase
-            .from('profiles')
+            .from("profiles")
             .insert({
               id: uid,
               email: session?.user?.email,
-              first_name: '',
-              last_name: '',
-              role: 'level1',
-              department: null
+              first_name: "",
+              last_name: "",
+              role: "level1",
+              department: null,
             });
 
           if (createError) {
-            console.error('[AuthProvider] Error creating profile:', createError);
+            console.error(
+              "[AuthProvider] Error creating profile:",
+              createError,
+            );
             setError({
-              code: createError.code || 'PROFILE_CREATE_ERROR',
-              message: createError.message || 'Failed to create user profile',
-              type: 'profile'
+              code: createError.code || "PROFILE_CREATE_ERROR",
+              message: createError.message || "Failed to create user profile",
+              type: "profile",
             });
             throw createError;
           }
 
           const { data: createdProfile } = await supabase
-            .from('profiles')
-            .select('*')
-            .eq('id', uid)
+            .from("profiles")
+            .select("*")
+            .eq("id", uid)
             .single();
 
           if (!createdProfile) {
-            throw new Error('Failed to fetch newly created profile');
+            throw new Error("Failed to fetch newly created profile");
           }
 
           const appUser: User = {
             id: createdProfile.id,
-            name: 'User',
+            name: "User",
             email: createdProfile.email,
             role: mapDatabaseRoleToAppRole(createdProfile.role),
-            department: createdProfile.department
+            department: createdProfile.department,
           };
           setUser(appUser);
           return;
@@ -378,40 +402,43 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       if (!data) {
-        throw new Error('Profile data is null');
+        throw new Error("Profile data is null");
       }
 
-      console.log('[AuthProvider] Profile loaded successfully:', data.email);
+      console.log("[AuthProvider] Profile loaded successfully:", data.email);
       const appUser: User = {
         id: data.id,
-        name: `${data.first_name || ''} ${data.last_name || ''}`.trim() || 'User',
+        name:
+          `${data.first_name || ""} ${data.last_name || ""}`.trim() || "User",
         email: data.email,
         role: mapDatabaseRoleToAppRole(data.role),
-        department: data.department
+        department: data.department,
       };
       setUser(appUser);
     } catch (err) {
-      console.error('[AuthProvider] Profile fetch error:', err);
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+      console.error("[AuthProvider] Profile fetch error:", err);
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
       setError({
-        code: 'PROFILE_FETCH_ERROR',
+        code: "PROFILE_FETCH_ERROR",
         message: errorMessage,
-        type: 'profile'
+        type: "profile",
       });
       throw err;
     }
   };
 
   return (
-    <AuthContext.Provider value={{
-      user,
-      session,
-      loading,
-      error,
-      signIn,
-      signOut,
-      refreshSession
-    }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        session,
+        loading,
+        error,
+        signIn,
+        signOut,
+        refreshSession,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/services/level4Service.ts
+++ b/src/services/level4Service.ts
@@ -1,9 +1,6 @@
-import { supabase } from '@/integrations/supabase/client';
-import type { Level4Config } from '@/components/level4/Level4ConfigTypes';
-import { 
-  Level4BOMValue, 
-  Level4RuntimePayload 
-} from '@/types/level4';
+import { supabase } from "@/integrations/supabase/client";
+import type { Level4Config } from "@/components/level4/Level4ConfigTypes";
+import { Level4BOMValue, Level4RuntimePayload } from "@/types/level4";
 
 /**
  * Represents the shape of the data in the `level4_configs` table.
@@ -12,7 +9,7 @@ interface Level4ConfigRow {
   id: string;
   product_id: string;
   field_label: string;
-  mode: 'fixed' | 'variable';
+  mode: "fixed" | "variable";
   fixed_number_of_inputs: number | null;
   variable_max_inputs: number | null;
   options: { id: string; name: string; url: string }[];
@@ -20,91 +17,108 @@ interface Level4ConfigRow {
 
 export class Level4Service {
   // Get Level 4 configuration for a Level 3 product
-  static async getLevel4Configuration(productId: string): Promise<Level4Config | null> {
+  static async getLevel4Configuration(
+    productId: string,
+  ): Promise<Level4Config | null> {
+    // Fetch without forcing a single row to avoid PGRST116 errors
     const { data, error } = await supabase
-      .from('level4_configs')
-      .select('*')
-      .eq('product_id', productId)
-      .maybeSingle();
+      .from("level4_configs")
+      .select("*")
+      .eq("product_id", productId);
 
-    if (error) {
-      console.error('Error loading Level 4 config:', error);
+    if (error && error.code !== "PGRST116") {
+      console.error("Error loading Level 4 config:", error);
       throw error;
     }
 
-    if (!data) {
+    // data may be an array when no rows are returned
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) {
       return null;
     }
 
     // Transform the database row into the Level4Config shape
     return {
-      id: data.id,
-      fieldLabel: data.field_label,
-      mode: data.mode,
-      fixed: data.mode === 'fixed' ? { numberOfInputs: data.fixed_number_of_inputs! } : undefined,
-      variable: data.mode === 'variable' ? { maxInputs: data.variable_max_inputs! } : undefined,
-      options: data.options || [],
+      id: row.id,
+      fieldLabel: row.field_label,
+      mode: row.mode,
+      fixed:
+        row.mode === "fixed"
+          ? { numberOfInputs: row.fixed_number_of_inputs! }
+          : undefined,
+      variable:
+        row.mode === "variable"
+          ? { maxInputs: row.variable_max_inputs! }
+          : undefined,
+      options: row.options || [],
     };
   }
 
   // Get all Level 3 products that have Level 4 enabled
   static async getLevel3ProductsWithLevel4(): Promise<any[]> {
-    console.log('Level4Service: Fetching all L3 products and L4 configs...');
+    console.log("Level4Service: Fetching all L3 products and L4 configs...");
 
-      // 1. Fetch all L3 products and all L4 config IDs in parallel.
-      const [productsResult, configsResult] = await Promise.all([
-        supabase
-        .from('products')
-        .select('id, name, parent_product_id, has_level4, enabled')
-        .eq('product_level', 3),
-        supabase
-        .from('level4_configs')
-        .select('product_id')
-      ]);
+    // 1. Fetch all L3 products and all L4 config IDs in parallel.
+    const [productsResult, configsResult] = await Promise.all([
+      supabase
+        .from("products")
+        .select("id, name, parent_product_id, has_level4, enabled")
+        .eq("product_level", 3),
+      supabase.from("level4_configs").select("product_id"),
+    ]);
 
-      const { data: allL3Products, error: productsError } = productsResult;
-      const { data: l4Configs, error: configsError } = configsResult;
+    const { data: allL3Products, error: productsError } = productsResult;
+    const { data: l4Configs, error: configsError } = configsResult;
 
-      if (productsError) {
-        console.error('Error loading L3 products:', productsError);
-        throw productsError;
-      }
-      if (configsError) {
-        // If there's any error fetching the configs (including 406), we must fail.
-        // The UI will catch this and display an appropriate message.
-        console.error('Error loading L4 configs:', configsError);
-        throw configsError;
-      }
+    if (productsError) {
+      console.error("Error loading L3 products:", productsError);
+      throw productsError;
+    }
+    if (configsError) {
+      // If there's any error fetching the configs (including 406), we must fail.
+      // The UI will catch this and display an appropriate message.
+      console.error("Error loading L4 configs:", configsError);
+      throw configsError;
+    }
 
-      // 2. Filter L3 products that are relevant for Level 4 configuration.
-      const configuredProductIds = new Set(l4Configs?.map(c => c.product_id) || []);
-      const relevantProducts = (allL3Products || []).filter(p => 
-        p.has_level4 || configuredProductIds.has(p.id)
-      );
+    // 2. Filter L3 products that are relevant for Level 4 configuration.
+    const configuredProductIds = new Set(
+      l4Configs?.map((c) => c.product_id) || [],
+    );
+    const relevantProducts = (allL3Products || []).filter(
+      (p) => p.has_level4 || configuredProductIds.has(p.id),
+    );
 
-      console.log('Level4Service: Total relevant L4 products:', relevantProducts.length);
-      return relevantProducts;
+    console.log(
+      "Level4Service: Total relevant L4 products:",
+      relevantProducts.length,
+    );
+    return relevantProducts;
   }
 
   // Create or update Level 4 configuration
-  static async saveLevel4Configuration(config: Level4Config, productId: string): Promise<Level4Config | null> {
-    const rowToSave: Omit<Level4ConfigRow, 'id' | 'created_at' | 'updated_at'> = {
-      product_id: productId,
-      field_label: config.fieldLabel,
-      mode: config.mode,
-      fixed_number_of_inputs: config.fixed?.numberOfInputs ?? null,
-      variable_max_inputs: config.variable?.maxInputs ?? null,
-      options: config.options,
-    };
+  static async saveLevel4Configuration(
+    config: Level4Config,
+    productId: string,
+  ): Promise<Level4Config | null> {
+    const rowToSave: Omit<Level4ConfigRow, "id" | "created_at" | "updated_at"> =
+      {
+        product_id: productId,
+        field_label: config.fieldLabel,
+        mode: config.mode,
+        fixed_number_of_inputs: config.fixed?.numberOfInputs ?? null,
+        variable_max_inputs: config.variable?.maxInputs ?? null,
+        options: config.options,
+      };
 
     const { data, error } = await supabase
-      .from('level4_configs')
-      .upsert(rowToSave, { onConflict: 'product_id' })
+      .from("level4_configs")
+      .upsert(rowToSave, { onConflict: "product_id" })
       .select()
       .single();
 
     if (error) {
-      console.error('Error saving Level 4 config:', error);
+      console.error("Error saving Level 4 config:", error);
       throw error;
     }
 
@@ -114,52 +128,66 @@ export class Level4Service {
       id: data.id,
       fieldLabel: data.field_label,
       mode: data.mode,
-      fixed: data.mode === 'fixed' ? { numberOfInputs: data.fixed_number_of_inputs! } : undefined,
-      variable: data.mode === 'variable' ? { maxInputs: data.variable_max_inputs! } : undefined,
+      fixed:
+        data.mode === "fixed"
+          ? { numberOfInputs: data.fixed_number_of_inputs! }
+          : undefined,
+      variable:
+        data.mode === "variable"
+          ? { maxInputs: data.variable_max_inputs! }
+          : undefined,
       options: data.options || [],
     };
   }
 
   // Save BOM Level 4 value (user selections)
-  static async saveBOMLevel4Value(bomItemId: string, payload: Level4RuntimePayload): Promise<Level4BOMValue | null> {
+  static async saveBOMLevel4Value(
+    bomItemId: string,
+    payload: Level4RuntimePayload,
+  ): Promise<Level4BOMValue | null> {
     try {
       const { data, error } = await supabase
-        .from('bom_level4_values')
-        .upsert({
-          bom_item_id: bomItemId,
-          level4_config_id: payload.configuration_id,
-          entries: payload.entries
-        }, {
-          onConflict: 'bom_item_id'
-        })
+        .from("bom_level4_values")
+        .upsert(
+          {
+            bom_item_id: bomItemId,
+            level4_config_id: payload.configuration_id,
+            entries: payload.entries,
+          },
+          {
+            onConflict: "bom_item_id",
+          },
+        )
         .select()
         .maybeSingle();
 
       if (error) throw error;
       return data || null;
     } catch (error) {
-      console.error('Error in saveBOMLevel4Value:', error);
+      console.error("Error in saveBOMLevel4Value:", error);
       throw error; // Re-throw the error to be handled by the caller
     }
   }
 
   // Get BOM Level 4 value
-  static async getBOMLevel4Value(bomItemId: string): Promise<Level4BOMValue | null> {
+  static async getBOMLevel4Value(
+    bomItemId: string,
+  ): Promise<Level4BOMValue | null> {
     try {
       const { data, error } = await supabase
-        .from('bom_level4_values')
-        .select('*')
-        .eq('bom_item_id', bomItemId)
+        .from("bom_level4_values")
+        .select("*")
+        .eq("bom_item_id", bomItemId)
         .maybeSingle();
 
       if (error) {
-        console.error('Error getting BOM Level 4 value:', error);
+        console.error("Error getting BOM Level 4 value:", error);
         return null;
       }
 
       return data || null;
     } catch (error) {
-      console.error('Error in getBOMLevel4Value:', error);
+      console.error("Error in getBOMLevel4Value:", error);
       return null;
     }
   }
@@ -168,35 +196,38 @@ export class Level4Service {
   static async deleteBOMLevel4Value(bomItemId: string): Promise<boolean> {
     try {
       const { error } = await supabase
-        .from('bom_level4_values')
+        .from("bom_level4_values")
         .delete()
-        .eq('bom_item_id', bomItemId);
+        .eq("bom_item_id", bomItemId);
 
       if (error) {
-        console.error('Error deleting BOM Level 4 value:', error);
+        console.error("Error deleting BOM Level 4 value:", error);
         return false;
       }
 
       return true;
     } catch (error) {
-      console.error('Error in deleteBOMLevel4Value:', error);
+      console.error("Error in deleteBOMLevel4Value:", error);
       return false;
     }
   }
 
   // Helper function to format Level 4 display
-  static formatLevel4Display(value: Level4BOMValue, config: Level4Config): string[] {
+  static formatLevel4Display(
+    value: Level4BOMValue,
+    config: Level4Config,
+  ): string[] {
     try {
       if (!value || !value.entries || !config) {
-        return ['Level 4 configuration error'];
+        return ["Level 4 configuration error"];
       }
 
       return value.entries.map((entry, index) => {
-        const option = config.options.find(opt => opt.id === entry.value);
+        const option = config.options.find((opt) => opt.id === entry.value);
         const label = option?.name || entry.value;
-        
+
         // Format based on template type
-        if (config.mode === 'variable') {
+        if (config.mode === "variable") {
           // Variable inputs: show entry number
           return `${config.fieldLabel} #${index + 1}: ${label}`;
         } else {
@@ -205,54 +236,65 @@ export class Level4Service {
         }
       });
     } catch (error) {
-      console.error('Error formatting Level 4 display:', error);
-      return ['Level 4 configuration error'];
+      console.error("Error formatting Level 4 display:", error);
+      return ["Level 4 configuration error"];
     }
   }
 
   // Get formatted summary for BOM display
-  static getLevel4Summary(value: Level4BOMValue, config?: Level4Config): string {
+  static getLevel4Summary(
+    value: Level4BOMValue,
+    config?: Level4Config,
+  ): string {
     try {
       if (!value || !value.entries || value.entries.length === 0) {
-        return 'No Level 4 configuration';
+        return "No Level 4 configuration";
       }
 
       const count = value.entries.length;
       const hasMultiple = count > 1;
-      
+
       if (config) {
-        const templateType = config.mode.charAt(0).toUpperCase() + config.mode.slice(1);
-        return `L4: ${count} ${config.fieldLabel.toLowerCase()}${hasMultiple ? 's' : ''} (${templateType})`;
+        const templateType =
+          config.mode.charAt(0).toUpperCase() + config.mode.slice(1);
+        return `L4: ${count} ${config.fieldLabel.toLowerCase()}${hasMultiple ? "s" : ""} (${templateType})`;
       }
-      
-      return `L4: ${count} selection${hasMultiple ? 's' : ''}`;
+
+      return `L4: ${count} selection${hasMultiple ? "s" : ""}`;
     } catch (error) {
-      console.error('Error generating Level 4 summary:', error);
-      return 'L4: Error';
+      console.error("Error generating Level 4 summary:", error);
+      return "L4: Error";
     }
   }
 
   // Validate Level 4 configuration completeness
-  static validateLevel4Configuration(value: Level4BOMValue, config: Level4Config): { isValid: boolean; errors: string[] } {
+  static validateLevel4Configuration(
+    value: Level4BOMValue,
+    config: Level4Config,
+  ): { isValid: boolean; errors: string[] } {
     const errors: string[] = [];
-    
+
     if (!value || !value.entries) {
-      errors.push('No Level 4 selections found');
+      errors.push("No Level 4 selections found");
       return { isValid: false, errors };
     }
 
-    if (config.mode === 'variable') {
+    if (config.mode === "variable") {
       const maxInputs = config.variable?.maxInputs || 1;
       if (value.entries.length > maxInputs) {
-        errors.push(`Too many selections: ${value.entries.length}/${maxInputs}`);
+        errors.push(
+          `Too many selections: ${value.entries.length}/${maxInputs}`,
+        );
       }
       if (value.entries.length === 0) {
-        errors.push('At least one selection is required');
+        errors.push("At least one selection is required");
       }
-    } else if (config.mode === 'fixed') {
+    } else if (config.mode === "fixed") {
       const requiredInputs = config.fixed?.numberOfInputs || 1;
       if (value.entries.length !== requiredInputs) {
-        errors.push(`Incorrect number of selections: ${value.entries.length}/${requiredInputs}`);
+        errors.push(
+          `Incorrect number of selections: ${value.entries.length}/${requiredInputs}`,
+        );
       }
     }
 
@@ -261,9 +303,13 @@ export class Level4Service {
       if (!entry.value) {
         errors.push(`Selection ${index + 1} is empty`);
       } else {
-        const isValidOption = config.options.some(opt => opt.id === entry.value);
+        const isValidOption = config.options.some(
+          (opt) => opt.id === entry.value,
+        );
         if (!isValidOption) {
-          errors.push(`Selection ${index + 1} has invalid option: ${entry.value}`);
+          errors.push(
+            `Selection ${index + 1} has invalid option: ${entry.value}`,
+          );
         }
       }
     });


### PR DESCRIPTION
## Summary
- avoid 406 errors when looking up level4 configuration by handling empty results
- extend profile fetch timeout to 8 seconds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ba336604e48326ae16688e2ce93890