### PR TITLE
Fix Level 4 card handling and preview interactions

### DIFF
--- a/src/components/bom/SlotCardSelector.tsx
+++ b/src/components/bom/SlotCardSelector.tsx
@@ -52,7 +52,8 @@ const SlotCardSelector = ({
           slotRequirement: product.specifications?.slotRequirement || 1,
           compatibleChassis: product.specifications?.compatibleChassis || [chassis.type],
           specifications: product.specifications,
-          partNumber: product.partNumber
+          partNumber: product.partNumber,
+          has_level4: (product as any)?.has_level4 === true
         }));
         
         setAvailableCards(cards);

--- a/src/components/level4/Level4RuntimeView.tsx
+++ b/src/components/level4/Level4RuntimeView.tsx
@@ -176,7 +176,10 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
         "border rounded-lg p-4 space-y-4",
         isReadOnly && "bg-muted/10"
       )}>
-        {entries.map((entry, idx) => (
+        {entries.map((entry, idx) => {
+          const selectedOption = configuration.options.find(opt => opt.value === entry.value);
+          const optionHasInfo = selectedOption?.info_url && isValidUrl(selectedOption.info_url);
+          return (
           <div key={`${entry.index}-${idx}`} className="space-y-2">
             <div className="flex items-center gap-2">
               <div className="flex-1 space-y-2">
@@ -196,7 +199,7 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
                   onValueChange={(value) => handleEntryChange(entry.index, value)}
                   disabled={isReadOnly}
                 >
-                  <SelectTrigger 
+                  <SelectTrigger
                     id={`entry-${entry.index}`}
                     className={cn(
                       validationErrors[entry.index] && "border-destructive focus:ring-destructive"
@@ -218,6 +221,24 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
                   </SelectContent>
                 </Select>
               </div>
+              {optionHasInfo && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  asChild
+                >
+                  <a
+                    href={normalizeUrl(selectedOption!.info_url!)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Option information"
+                  >
+                    <Info className="h-4 w-4" />
+                  </a>
+                </Button>
+              )}
 
               {/* Add/Remove buttons for variable inputs */}
               {allowInteractions && configuration.template_type === 'OPTION_1' && (
@@ -246,7 +267,7 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
               )}
             </div>
           </div>
-        ))}
+        );})}
 
         {/* Add more button for variable inputs */}
         {allowInteractions && 

--- a/src/services/productDataService.ts
+++ b/src/services/productDataService.ts
@@ -189,7 +189,7 @@ class ProductDataService {
         partNumber: product.part_number,
         image: product.image_url,
         productInfoUrl: product.product_info_url,
-        has_level4: product.has_level4 || false,
+        has_level4: product.has_level4 === true,
         specifications: product.specifications || {}
       }));
 
@@ -401,7 +401,7 @@ class ProductDataService {
             product_level: 3,
             parent_product_id: productData.parentProductId,
             category: productData.type || 'standard',
-            has_level4: (productData as any).has_level4 || false,
+            has_level4: (productData as any).has_level4 === true,
             specifications: productData.specifications || {}
           }
         ])
@@ -422,7 +422,7 @@ class ProductDataService {
         price: data.price || 0,
         cost: data.cost || 0,
         enabled: data.enabled !== false,
-        has_level4: data.has_level4 || false,
+        has_level4: data.has_level4 === true,
         specifications: data.specifications || {}
       };
 
@@ -908,7 +908,7 @@ class ProductDataService {
           partNumber: data.part_number,
           image: data.image_url,
           productInfoUrl: data.product_info_url,
-          has_level4: data.has_level4 || false,
+          has_level4: data.has_level4 === true,
           sku: data.sku,
           specifications: data.specifications || {}
         } as Level3Product;


### PR DESCRIPTION
## Summary
- propagate `has_level4` flag from Level-3 products through SlotCardSelector
- ensure product data service keeps `has_level4` boolean from Supabase
- enrich Level4 runtime view with option info links and interactive controls for preview

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any errors, require import restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68c3159980488326a6d84396f88d990f