### PR TITLE
Fix Level 4 card handling, preview interactions, and dropdown styling

### DIFF
--- a/src/components/bom/SlotCardSelector.tsx
+++ b/src/components/bom/SlotCardSelector.tsx
@@ -52,7 +52,8 @@ const SlotCardSelector = ({
           slotRequirement: product.specifications?.slotRequirement || 1,
           compatibleChassis: product.specifications?.compatibleChassis || [chassis.type],
           specifications: product.specifications,
-          partNumber: product.partNumber
+          partNumber: product.partNumber,
+          has_level4: (product as any)?.has_level4 === true
         }));
         
         setAvailableCards(cards);

--- a/src/components/level4/Level4RuntimeModal.tsx
+++ b/src/components/level4/Level4RuntimeModal.tsx
@@ -49,7 +49,7 @@ export const Level4RuntimeModal: React.FC<Level4RuntimeModalProps> = ({
         setAdminConfig(config);
         
         // Convert to runtime format
-        const runtime = Level4Service.convertToRuntimeConfiguration(config);
+        const runtime = Level4Service.convertToRuntimeConfiguration(config, level3ProductId);
         console.log('Converted to runtime config:', runtime);
         setRuntimeConfig(runtime);
 

--- a/src/components/level4/Level4RuntimeView.tsx
+++ b/src/components/level4/Level4RuntimeView.tsx
@@ -176,7 +176,10 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
         "border rounded-lg p-4 space-y-4",
         isReadOnly && "bg-muted/10"
       )}>
-        {entries.map((entry, idx) => (
+        {entries.map((entry, idx) => {
+          const selectedOption = configuration.options.find(opt => opt.value === entry.value);
+          const optionHasInfo = selectedOption?.info_url && isValidUrl(selectedOption.info_url);
+          return (
           <div key={`${entry.index}-${idx}`} className="space-y-2">
             <div className="flex items-center gap-2">
               <div className="flex-1 space-y-2">
@@ -192,11 +195,11 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
                 </div>
                 
                 <Select
-                  value={entry.value}
+                  value={entry.value || undefined}
                   onValueChange={(value) => handleEntryChange(entry.index, value)}
                   disabled={isReadOnly}
                 >
-                  <SelectTrigger 
+                  <SelectTrigger
                     id={`entry-${entry.index}`}
                     className={cn(
                       validationErrors[entry.index] && "border-destructive focus:ring-destructive"
@@ -208,7 +211,11 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
                     {configuration.options
                       .sort((a, b) => a.display_order - b.display_order)
                       .map(option => (
-                        <SelectItem key={option.id} value={option.value}>
+                        <SelectItem
+                          key={option.id}
+                          value={option.value}
+                          className="text-foreground"
+                        >
                           {option.label}
                           {option.is_default && isReadOnly && (
                             <span className="ml-2 text-xs text-muted-foreground">(default)</span>
@@ -218,6 +225,24 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
                   </SelectContent>
                 </Select>
               </div>
+              {optionHasInfo && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  asChild
+                >
+                  <a
+                    href={normalizeUrl(selectedOption!.info_url!)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Option information"
+                  >
+                    <Info className="h-4 w-4" />
+                  </a>
+                </Button>
+              )}
 
               {/* Add/Remove buttons for variable inputs */}
               {allowInteractions && configuration.template_type === 'OPTION_1' && (
@@ -246,7 +271,7 @@ export const Level4RuntimeView: React.FC<Level4RuntimeViewProps> = ({
               )}
             </div>
           </div>
-        ))}
+        );})}
 
         {/* Add more button for variable inputs */}
         {allowInteractions && 

--- a/src/services/level4Service.ts
+++ b/src/services/level4Service.ts
@@ -1,6 +1,17 @@
 import { supabase } from '@/integrations/supabase/client';
 import type { Level4Configuration, Level4BOMValue, Level4RuntimePayload } from '@/types/level4';
-import type { Level4Config } from '@/components/level4/Level4ConfigTypes';
+import type { Level4Config, DropdownOption } from '@/components/level4/Level4ConfigTypes';
+import type { Level3Product } from '@/types/product/interfaces';
+
+interface Level4ConfigRow {
+  id: string;
+  product_id: string;
+  field_label: string;
+  mode: 'fixed' | 'variable';
+  fixed_number_of_inputs?: number | null;
+  variable_max_inputs?: number | null;
+  options: DropdownOption[];
+}
 
 export class Level4Service {
   /**
@@ -9,7 +20,7 @@ export class Level4Service {
   static async getLevel4Configuration(level3ProductId: string): Promise<Level4Config | null> {
     try {
       console.log('Fetching Level 4 config for product:', level3ProductId);
-      
+
       const { data, error } = await supabase
         .from('level4_configs')
         .select('*')
@@ -24,8 +35,23 @@ export class Level4Service {
         throw error;
       }
 
-      console.log('Found Level 4 config:', data);
-      return data;
+      if (!data) {
+        return null;
+      }
+
+      const row = data as Level4ConfigRow;
+
+      const mapped: Level4Config = {
+        id: row.id,
+        fieldLabel: row.field_label,
+        mode: row.mode,
+        fixed: row.fixed_number_of_inputs != null ? { numberOfInputs: row.fixed_number_of_inputs } : undefined,
+        variable: row.variable_max_inputs != null ? { maxInputs: row.variable_max_inputs } : undefined,
+        options: Array.isArray(row.options) ? row.options : [],
+      };
+
+      console.log('Found Level 4 config:', mapped);
+      return mapped;
     } catch (error) {
       console.error('Level4Service.getLevel4Configuration error:', error);
       throw error;
@@ -35,25 +61,25 @@ export class Level4Service {
   /**
    * Convert admin Level4Config to runtime Level4Configuration format
    */
-  static convertToRuntimeConfiguration(adminConfig: Level4Config): Level4Configuration {
-    const options = Array.isArray(adminConfig.options) ? adminConfig.options : [];
-    
+  static convertToRuntimeConfiguration(adminConfig: Level4Config, level3ProductId?: string): Level4Configuration {
+    const options: DropdownOption[] = Array.isArray(adminConfig.options) ? adminConfig.options : [];
+
     return {
       id: adminConfig.id,
-      level3_product_id: adminConfig.id, // Using config ID as reference
+      level3_product_id: level3ProductId ?? adminConfig.id,
       template_type: adminConfig.mode === 'fixed' ? 'OPTION_2' : 'OPTION_1',
       field_label: adminConfig.fieldLabel,
       max_inputs: adminConfig.mode === 'variable' ? adminConfig.variable?.maxInputs : null,
       fixed_inputs: adminConfig.mode === 'fixed' ? adminConfig.fixed?.numberOfInputs : null,
-      options: options.map((opt: any, index: number) => ({
+      options: options.map((opt, index) => ({
         id: opt.id,
         level4_configuration_id: adminConfig.id,
         label: opt.name,
         value: opt.id,
         display_order: index,
         is_default: index === 0,
-        info_url: opt.url || null
-      }))
+        info_url: opt.url || null,
+      })),
     };
   }
 
@@ -91,7 +117,8 @@ export class Level4Service {
         .from('bom_level4_values')
         .upsert({
           bom_item_id: bomItemId,
-          level4_config_id: payload.configuration_id,
+          level4_configuration_id: payload.configuration_id,
+          template_type: payload.template_type,
           entries: payload.entries
         });
 
@@ -162,19 +189,20 @@ export class Level4Service {
   /**
    * Get Level 3 products with Level 4 configurations (for admin panel)
    */
-  static async getLevel3ProductsWithLevel4(): Promise<any[]> {
+  static async getLevel3ProductsWithLevel4(): Promise<Level3Product[]> {
     try {
       const { data, error } = await supabase
         .from('products')
         .select('*')
         .eq('product_level', 3)
-        .eq('enabled', true);
+        .eq('enabled', true)
+        .eq('has_level4', true);
 
       if (error) {
         throw error;
       }
 
-      return data || [];
+      return (data as Level3Product[]) || [];
     } catch (error) {
       console.error('Level4Service.getLevel3ProductsWithLevel4 error:', error);
       throw error;

--- a/src/services/productDataService.ts
+++ b/src/services/productDataService.ts
@@ -189,7 +189,7 @@ class ProductDataService {
         partNumber: product.part_number,
         image: product.image_url,
         productInfoUrl: product.product_info_url,
-        has_level4: product.has_level4 || false,
+        has_level4: product.has_level4 === true,
         specifications: product.specifications || {}
       }));
 
@@ -401,7 +401,7 @@ class ProductDataService {
             product_level: 3,
             parent_product_id: productData.parentProductId,
             category: productData.type || 'standard',
-            has_level4: (productData as any).has_level4 || false,
+            has_level4: (productData as any).has_level4 === true,
             specifications: productData.specifications || {}
           }
         ])
@@ -422,7 +422,7 @@ class ProductDataService {
         price: data.price || 0,
         cost: data.cost || 0,
         enabled: data.enabled !== false,
-        has_level4: data.has_level4 || false,
+        has_level4: data.has_level4 === true,
         specifications: data.specifications || {}
       };
 
@@ -908,7 +908,7 @@ class ProductDataService {
           partNumber: data.part_number,
           image: data.image_url,
           productInfoUrl: data.product_info_url,
-          has_level4: data.has_level4 || false,
+          has_level4: data.has_level4 === true,
           sku: data.sku,
           specifications: data.specifications || {}
         } as Level3Product;


### PR DESCRIPTION
## Summary
- propagate `has_level4` flag from Level-3 products through SlotCardSelector
- ensure product data service keeps `has_level4` boolean from Supabase
- enrich Level4 runtime view with option info links and interactive controls for preview
- only list Level-3 products with Level-4 enabled in admin panel
- map stored Level-4 configs to typed objects and pass product IDs so fixed/variable inputs render correctly
- allow runtime Select components to handle empty values and open as expected
- fix Level-4 dropdown styling so option text remains visible on light backgrounds
- include template type when saving BOM Level-4 values so configurations persist correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any, A `require()` style import is forbidden @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68c3159980488326a6d84396f88d990f