### PR TITLE
Fix Level 4 configuration temporary quote creation

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -563,7 +563,7 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
       console.log('Setting up Level 4 config for user:', user.id);
       
       // Create temporary quote and BOM item in database
-      const { bomItemId, tempQuoteId } = await Level4Service.createBOMItemForLevel4Config(newItem);
+      const { bomItemId, tempQuoteId } = await Level4Service.createBOMItemForLevel4Config(newItem, user.id);
       
       // Update the item with database ID
       const itemWithDbId: BOMItem = {


### PR DESCRIPTION
## Summary
- ensure Level4Service temporary quote creation can accept an explicit user id and fall back to the authenticated session when needed
- require a user id when creating temporary BOM items for Level 4 configuration to guarantee the quote is tied to a user
- forward the authenticated user's id from the BOM builder when setting up Level 4 configuration

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cf25828c64832689ea487c907c63ac