### PR TITLE
Ensure Level 4 temp quotes include authenticated user

### DIFF
--- a/src/components/level4/Level4RuntimeModal.tsx
+++ b/src/components/level4/Level4RuntimeModal.tsx
@@ -11,7 +11,7 @@ import type { Level4Config } from './Level4ConfigTypes';
 interface Level4RuntimeModalProps {
   bomItem: BOMItem;
   level3ProductId: string;
-  onSave: (payload: Level4RuntimePayload) => void;
+  onSave: (payload: Level4RuntimePayload, context?: { bomItemId: string; tempQuoteId?: string }) => void;
   onCancel: () => void;
 }
 
@@ -142,11 +142,16 @@ export const Level4RuntimeModal: React.FC<Level4RuntimeModalProps> = ({
       console.log('Runtime Config:', runtimeConfig);
 
       // Save the configuration
-      await Level4Service.saveBOMLevel4Value(bomItem.id, payload);
-      
+      const result = await Level4Service.saveBOMLevel4Value(bomItem, payload);
+
+      const resolvedPayload: Level4RuntimePayload = {
+        ...payload,
+        bomItemId: result.bomItemId,
+      };
+
       // Notify parent component
-      onSave(payload);
-      
+      onSave(resolvedPayload, result);
+
       toast.success('Level 4 configuration saved successfully');
     } catch (error) {
       console.error('Error saving Level 4 configuration:', error);


### PR DESCRIPTION
## Summary
- pull the Supabase session ID when preparing Level 4 temporary quotes and ensure the user identifier is sanitized before inserting
- use the active Supabase session in the BOM builder when spawning temporary Level 4 BOM items so authenticated IDs are always passed through

## Testing
- npm run lint *(fails: numerous pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf25828c64832689ea487c907c63ac