### PR TITLE
Improve Level 4 session persistence and BOM updates

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -597,6 +597,7 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
     if (configuringLevel4Item) {
       const updatedItem: BOMItem = {
         ...configuringLevel4Item,
+        id: payload.bomItemId,
         level4Config: payload,
         product: {
           ...configuringLevel4Item.product,
@@ -605,9 +606,17 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
         displayName: (configuringLevel4Item as any).displayName || configuringLevel4Item.product.name
       };
 
-      const existingIndex = bomItems.findIndex(item => item.id === configuringLevel4Item.id);
+      if ((configuringLevel4Item as any).tempQuoteId) {
+        (updatedItem as any).tempQuoteId = (configuringLevel4Item as any).tempQuoteId;
+      }
+
+      const existingIndex = bomItems.findIndex(item =>
+        item.id === configuringLevel4Item.id || item.id === payload.bomItemId
+      );
       const updatedItems = existingIndex >= 0
-        ? bomItems.map(item => (item.id === payload.bomItemId ? updatedItem : item))
+        ? bomItems.map(item =>
+            (item.id === configuringLevel4Item.id || item.id === payload.bomItemId) ? updatedItem : item
+          )
         : [...bomItems, updatedItem];
 
       setBomItems(updatedItems);


### PR DESCRIPTION
## Summary
- add Level 4 session tracking inside the runtime modal so temporary BOM items are recreated when missing and the modal keeps its session metadata in sync
- extend the Level4Service save routine to automatically recreate temporary BOM items, keep sessions registered, and report the final BOM/temp quote identifiers
- update the BOM builder to respect updated BOM item identifiers and retain temporary quote references when saving configurations

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d00ef61280832680d91e9d1e135baf