### PR TITLE
Improve Level 4 slot actions

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -436,32 +436,102 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
     setSelectedSlot(slot);
   };
 
+  const cleanupLevel4BomItem = async (bomItemId: string) => {
+    if (!bomItemId) return;
+
+    try {
+      const { Level4Service } = await import('@/services/level4Service');
+
+      try {
+        Level4Service.unregisterActiveSession(bomItemId);
+      } catch (error) {
+        console.warn('Failed to unregister Level 4 session during cleanup:', error);
+      }
+
+      try {
+        await Level4Service.deleteTempBOMItem(bomItemId, true);
+      } catch (error) {
+        console.warn('Failed to delete Level 4 BOM item during cleanup:', error);
+      }
+    } catch (error) {
+      console.error('Error cleaning up Level 4 BOM item:', error);
+    }
+  };
+
   const handleSlotClear = (slot: number) => {
+    const bomItemsToCleanup = new Set<string>();
+
     setSlotAssignments(prev => {
       const updated = { ...prev };
       const card = updated[slot];
-      
+
       if (card && isBushingCard(card)) {
         const bushingSlots = findExistingBushingSlots(updated);
         bushingSlots.forEach(bushingSlot => {
+          const bushingCard = updated[bushingSlot];
+          const bomItemId = (bushingCard as any)?.level4BomItemId as string | undefined;
+          if (bomItemId) {
+            bomItemsToCleanup.add(bomItemId);
+          }
           delete updated[bushingSlot];
         });
       } else {
+        const bomItemId = (card as any)?.level4BomItemId as string | undefined;
+        if (bomItemId) {
+          bomItemsToCleanup.add(bomItemId);
+        }
         delete updated[slot];
       }
-      
+
       return updated;
     });
+
+    if (bomItemsToCleanup.size > 0) {
+      bomItemsToCleanup.forEach(bomItemId => {
+        void cleanupLevel4BomItem(bomItemId);
+      });
+    }
   };
 
   const handleCardSelect = (card: any, slot: number) => {
     const updatedAssignments = { ...slotAssignments };
     const displayName = (card as any).displayName || card.name;
-    
+
+    const bomItemsToCleanup = new Set<string>();
+
+    const removeExistingAssignment = (targetSlot: number) => {
+      const existing = updatedAssignments[targetSlot];
+      if (!existing) return;
+
+      const existingBomId = (existing as any)?.level4BomItemId as string | undefined;
+      if (existingBomId) {
+        bomItemsToCleanup.add(existingBomId);
+      }
+
+      delete updatedAssignments[targetSlot];
+    };
+
+    const existingAtSlot = updatedAssignments[slot];
+    if (existingAtSlot) {
+      if (isBushingCard(existingAtSlot)) {
+        const pairSlot = (existingAtSlot as any)?.bushingPairSlot as number | undefined;
+        if (pairSlot) {
+          removeExistingAssignment(pairSlot);
+        }
+      }
+      removeExistingAssignment(slot);
+    }
+
     // Create card with display name
+    const requiresLevel4Configuration = Boolean(
+      (card as any).has_level4 ||
+      (card as any).requires_level4_config
+    );
+
     const cardWithDisplayName = {
       ...card,
-      displayName: displayName
+      displayName: displayName,
+      hasLevel4Configuration: requiresLevel4Configuration
     };
     
     // Handle bushing cards
@@ -476,24 +546,32 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
         ...cardWithDisplayName,
         isBushingPrimary: true,
         bushingPairSlot: secondarySlot,
-        displayName: displayName // Use the display name from level 3 config
+        displayName: displayName, // Use the display name from level 3 config
+        hasLevel4Configuration: requiresLevel4Configuration
       };
-      
+
       // Assign to secondary slot
       updatedAssignments[secondarySlot] = {
         ...cardWithDisplayName,
         isBushingSecondary: true,
         bushingPairSlot: primarySlot,
-        displayName: displayName // Use the same display name as primary slot
+        displayName: displayName, // Use the same display name as primary slot
+        hasLevel4Configuration: requiresLevel4Configuration
       };
     } else {
       // Regular card assignment
       updatedAssignments[slot] = cardWithDisplayName;
     }
-    
+
     // Only set state once after all updates
     setSlotAssignments(updatedAssignments);
-    
+
+    if (bomItemsToCleanup.size > 0) {
+      bomItemsToCleanup.forEach(id => {
+        void cleanupLevel4BomItem(id);
+      });
+    }
+
     // Check if this card requires level 4 configuration
     console.log('Card level 4 check:', {
       card: card.name,
@@ -551,7 +629,7 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
   const handleLevel4Setup = async (newItem: BOMItem) => {
     try {
       setIsLoading(true);
-      
+
       // Import Level4Service dynamically to avoid circular imports
       const { Level4Service } = await import('@/services/level4Service');
       
@@ -591,8 +669,106 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
     }
   };
 
+  const handleSlotLevel4Reconfigure = (slot: number) => {
+    const card = slotAssignments[slot];
+    if (!card) return;
+
+    const displayName = (card as any).displayName || card.name;
+    const partNumber = (card as any).partNumber || card.partNumber || '';
+    const level4BomItemId = (card as any)?.level4BomItemId as string | undefined;
+    const tempQuoteId = (card as any)?.level4TempQuoteId as string | undefined;
+
+    if (!level4BomItemId) {
+      setSelectedSlot(slot);
+
+      const newItem: BOMItem = {
+        id: crypto.randomUUID(),
+        product: {
+          ...card,
+          displayName,
+        },
+        quantity: 1,
+        enabled: true,
+        partNumber,
+        displayName,
+        slot,
+      };
+
+      handleLevel4Setup(newItem);
+      return;
+    }
+
+    const reconfigureItem = {
+      id: level4BomItemId,
+      product: {
+        ...card,
+        displayName,
+      },
+      quantity: 1,
+      enabled: true,
+      partNumber,
+      displayName,
+      slot,
+      level4Config: (card as any)?.level4Config,
+    } as BOMItem & { isReconfigureSession?: boolean };
+
+    if (tempQuoteId) {
+      (reconfigureItem as any).tempQuoteId = tempQuoteId;
+    }
+
+    reconfigureItem.isReconfigureSession = true;
+
+    setConfiguringLevel4Item(reconfigureItem);
+    setSelectedSlot(slot);
+  };
+
   const handleLevel4Save = (payload: Level4RuntimePayload) => {
     console.log('Saving Level 4 configuration:', payload);
+
+    if (configuringLevel4Item?.slot !== undefined) {
+      const slot = configuringLevel4Item.slot;
+      const tempQuoteId = (configuringLevel4Item as any)?.tempQuoteId as string | undefined;
+      const displayName = (configuringLevel4Item as any).displayName || configuringLevel4Item.product.name;
+
+      setSlotAssignments(prev => {
+        const updated = { ...prev };
+
+        const applyUpdate = (targetSlot: number) => {
+          const existingCard = updated[targetSlot];
+          if (!existingCard) return;
+
+          updated[targetSlot] = {
+            ...existingCard,
+            displayName: (existingCard as any).displayName || existingCard.name,
+            level4Config: payload,
+            level4BomItemId: payload.bomItemId,
+            level4TempQuoteId: tempQuoteId,
+            hasLevel4Configuration: true
+          } as Level3Product;
+        };
+
+        applyUpdate(slot);
+
+        const primaryCard = updated[slot];
+        if (primaryCard && isBushingCard(primaryCard)) {
+          const pairedSlot = (primaryCard as any)?.bushingPairSlot as number | undefined;
+          if (pairedSlot) {
+            applyUpdate(pairedSlot);
+          }
+        }
+
+        return updated;
+      });
+
+      toast({
+        title: 'Configuration Saved',
+        description: `${displayName} configuration has been saved.`,
+      });
+
+      setConfiguringLevel4Item(null);
+      setSelectedSlot(null);
+      return;
+    }
 
     if (configuringLevel4Item) {
       const updatedItem: BOMItem = {
@@ -637,19 +813,23 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
       try {
         // Import Level4Service dynamically to avoid circular imports
         const { Level4Service } = await import('@/services/level4Service');
-        
+
         console.log('Canceling Level 4 configuration for item:', configuringLevel4Item.id);
-        
+
         // Unregister the active session and force cleanup on cancel
         Level4Service.unregisterActiveSession(configuringLevel4Item.id);
-        
-        // Clean up temporary data immediately on cancel
-        try {
-          await Level4Service.deleteTempBOMItem(configuringLevel4Item.id, true); // Force cleanup
-        } catch (error) {
-          console.error('Error cleaning up Level 4 configuration:', error);
+
+        const isReconfigureSession = Boolean((configuringLevel4Item as any)?.isReconfigureSession);
+
+        // Clean up temporary data immediately on cancel when this is a new configuration session
+        if (!isReconfigureSession) {
+          try {
+            await Level4Service.deleteTempBOMItem(configuringLevel4Item.id, true); // Force cleanup
+          } catch (error) {
+            console.error('Error cleaning up Level 4 configuration:', error);
+          }
         }
-        
+
       } catch (error) {
         console.error('Error preparing Level 4 cleanup:', error);
         // Don't block the cancel operation
@@ -1169,7 +1349,8 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
             selectedAccessories={selectedAccessories}
             onAccessoryToggle={toggleAccessory}
             partNumber={buildQTMSPartNumber({ chassis: configuringChassis, slotAssignments, hasRemoteDisplay, pnConfig, codeMap, includeSuffix: false })}
-            
+            onSlotReconfigure={handleSlotLevel4Reconfigure}
+
           />
           
           {selectedSlot !== null && (
@@ -1256,6 +1437,7 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false }: BOMBuild
                 selectedAccessories={selectedAccessories}
                 onAccessoryToggle={toggleAccessory}
                 partNumber={buildQTMSPartNumber({ chassis: selectedChassis, slotAssignments, hasRemoteDisplay, pnConfig, codeMap, includeSuffix: false })}
+                onSlotReconfigure={handleSlotLevel4Reconfigure}
               />
             
               {selectedSlot !== null && (

--- a/src/components/bom/RackVisualizer.tsx
+++ b/src/components/bom/RackVisualizer.tsx
@@ -1,9 +1,8 @@
-import { Chassis, Card as ProductCard, Level3Product } from "@/types/product";
+import { Chassis, Level3Product } from "@/types/product";
 import { ChassisType } from "@/types/product/chassis-types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { X } from "lucide-react";
+import { Settings, X } from "lucide-react";
 import { getBushingOccupiedSlots, isBushingCard } from "@/utils/bushingValidation";
 import AccessoryList from "./AccessoryList";
 
@@ -34,14 +33,15 @@ interface RackVisualizerProps {
   onAccessoryToggle?: (id: string) => void;
   partNumber?: string;
   chassisType?: ChassisType; // Optional chassis type for custom layouts
-  
+  onSlotReconfigure?: (slot: number) => void;
+
 }
 
-const RackVisualizer = ({ 
-  chassis, 
-  slotAssignments, 
-  onSlotClick, 
-  onSlotClear, 
+const RackVisualizer = ({
+  chassis,
+  slotAssignments,
+  onSlotClick,
+  onSlotClear,
   selectedSlot,
   hasRemoteDisplay = false,
   onRemoteDisplayToggle,
@@ -53,10 +53,16 @@ const RackVisualizer = ({
   onAccessoryToggle,
   partNumber,
   chassisType,
-  
+  onSlotReconfigure,
+
 }: RackVisualizerProps) => {
-  
+
   const bushingSlots = getBushingOccupiedSlots(slotAssignments);
+
+  const getCardDisplayName = (card?: Level3Product) => {
+    if (!card) return '';
+    return (card as any).displayName || card.displayName || card.name || card.type || 'Card';
+  };
 
   const getCardTypeColor = (cardType: string) => {
     switch (cardType) {
@@ -83,10 +89,10 @@ const getSlotColor = (slot: number) => {
       const card = slotAssignments[slot];
       if (isBushingCard(card)) {
         // Always show just the display name without slot number
-        return card.displayName || 'Bushing';
+        return getCardDisplayName(card) || 'Bushing';
       }
       // For non-bushing cards, use the existing logic
-      const displayText = (card as any).displayName || card.type || card.name || 'Card';
+      const displayText = getCardDisplayName(card);
       return displayText.charAt(0).toUpperCase() + displayText.slice(1);
     }
     // For empty slots, just show the slot number
@@ -98,17 +104,13 @@ const getSlotTitle = (slot: number) => {
     const card = slotAssignments[slot];
     if (isBushingCard(card)) {
       // For bushing cards, show only the display name
-      return card.displayName || 'Bushing';
+      return getCardDisplayName(card) || 'Bushing';
     }
-    
+
     // For non-bushing cards, use the existing logic
-    const displayText = (card as any).displayName || 
-                       (card?.type ? (card.type.charAt(0).toUpperCase() + card.type.slice(1)) : '') || 
-                       card?.name || 
-                       'Card';
-    return displayText;
+    return getCardDisplayName(card) || 'Card';
   }
-  
+
   // Empty slots - show standard hints when available
   const hints = standardSlotHints?.[slot];
   if (hints && hints.length) {
@@ -148,8 +150,8 @@ const getSlotTitle = (slot: number) => {
     const assignedCard = slotAssignments[slot];
     
     // Get display name from the card, with proper fallbacks
-    const displayName = assignedCard ? 
-      ((assignedCard as any).displayName || assignedCard.name || 'Card') : 
+    const displayName = assignedCard ?
+      (getCardDisplayName(assignedCard) || 'Card') :
       undefined;
     
     // Get the full title for the tooltip
@@ -316,7 +318,10 @@ const getSlotTitle = (slot: number) => {
               <div className="space-y-1 text-sm">
                 {Object.entries(bushingSlots).map(([slot, occupiedSlots]) => (
                   <div key={slot} className="text-orange-300">
-                    Slots {occupiedSlots.join(', ')}: {(() => { const c = slotAssignments[parseInt(slot)]; const t = c?.type || ''; return t ? (t.charAt(0).toUpperCase() + t.slice(1)) : (c?.name || 'Card'); })()}
+                    Slots {occupiedSlots.join(', ')}: {(() => {
+                      const card = slotAssignments[parseInt(slot)];
+                      return getCardDisplayName(card) || 'Card';
+                    })()}
                     <br />
                     <span className="text-xs text-orange-200">
                       (Only one bushing card allowed per chassis)
@@ -342,24 +347,93 @@ const getSlotTitle = (slot: number) => {
           
           
           {/* Slot assignments summary */}
-          {Object.keys(slotAssignments).length > 0 && (
+          {(chassis.slots || chassis.specifications?.slots || Object.keys(slotAssignments).length > 0) && (
             <div className="pt-4 border-t border-gray-700">
               <h4 className="text-white font-medium mb-2">Assigned Cards:</h4>
               <div className="space-y-1">
-                {Object.entries(bushingSlots).map(([slot, slots]) => (
-                  <div key={`bushing-${slot}`} className="flex justify-between text-sm">
-                    <span className="text-gray-400">Slots {slots.join('-')}:</span>
-                    <span className="text-white">{(() => { const c = slotAssignments[parseInt(slot)]; const t = c?.type || ''; return t ? (t.charAt(0).toUpperCase() + t.slice(1)) : (c?.name || 'Card'); })()}</span>
-                  </div>
-                ))}
-                {Object.entries(slotAssignments)
-                  .filter(([slot, card]) => !isBushingCard(card))
-                  .map(([slot, card]) => (
-                    <div key={slot} className="flex justify-between text-sm">
-                      <span className="text-gray-400">Slot {slot}:</span>
-                      <span className="text-white">{card.type ? (card.type.charAt(0).toUpperCase() + card.type.slice(1)) : (card.name || 'Card')}</span>
+                {Object.entries(bushingSlots).map(([slot, slots]) => {
+                  const primarySlot = parseInt(slot, 10);
+                  const card = slotAssignments[primarySlot];
+                  const label = getCardDisplayName(card) || 'Card';
+                  const hasLevel4Config = Boolean(
+                    (card as any)?.hasLevel4Configuration ||
+                    (card as any)?.level4BomItemId ||
+                    (card as any)?.level4Config ||
+                    (card as any)?.has_level4 ||
+                    (card as any)?.requires_level4_config
+                  );
+                  const hasExistingConfig = Boolean((card as any)?.level4BomItemId);
+                  const srLabel = `${hasExistingConfig ? 'Reconfigure' : 'Configure'} ${label}`;
+
+                  return (
+                    <div key={`bushing-${slot}`} className="flex items-center justify-between gap-2 text-sm">
+                      <div className="flex items-center gap-2">
+                        <span className="text-gray-400">Slots {slots.join('-')}:</span>
+                        <span className="text-white">{label}</span>
+                      </div>
+                      {hasLevel4Config && !!onSlotReconfigure && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 border border-gray-700 text-gray-200 hover:text-white"
+                          onClick={() => onSlotReconfigure(primarySlot)}
+                          title={srLabel}
+                        >
+                          <Settings className="h-3.5 w-3.5" />
+                          <span className="sr-only">{srLabel}</span>
+                        </Button>
+                      )}
                     </div>
-                  ))}
+                  );
+                })}
+                {(() => {
+                  const totalSlots = chassis.slots || chassis.specifications?.slots || 0;
+                  const slotOrder = totalSlots > 0
+                    ? Array.from({ length: totalSlots }, (_, index) => index + 1)
+                    : Object.keys(slotAssignments)
+                        .map(Number)
+                        .sort((a, b) => a - b);
+
+                  return slotOrder.map(slot => {
+                    const card = slotAssignments[slot];
+                    const isEmpty = !card;
+                    const isSecondaryBushing = Boolean((card as any)?.isBushingSecondary);
+                    const label = isEmpty ? 'Empty' : getCardDisplayName(card);
+                    const hasLevel4Config = Boolean(
+                      (card as any)?.hasLevel4Configuration ||
+                      (card as any)?.level4BomItemId ||
+                      (card as any)?.level4Config ||
+                      (card as any)?.has_level4 ||
+                      (card as any)?.requires_level4_config
+                    );
+                    const hasExistingConfig = Boolean((card as any)?.level4BomItemId);
+                    const showReconfigureButton = !isEmpty && !isSecondaryBushing && !!onSlotReconfigure && hasLevel4Config;
+                    const srLabel = `${hasExistingConfig ? 'Reconfigure' : 'Configure'} ${label || 'card'}`;
+
+                    return (
+                      <div key={slot} className="flex items-center justify-between gap-2 text-sm">
+                        <div className="flex items-center gap-2">
+                          <span className="text-gray-400">Slot {slot}:</span>
+                          <span className={isEmpty ? 'text-gray-500 italic' : 'text-white'}>
+                            {label || 'Card'}
+                          </span>
+                        </div>
+                        {showReconfigureButton && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-7 w-7 border border-gray-700 text-gray-200 hover:text-white"
+                            onClick={() => onSlotReconfigure?.(slot)}
+                            title={srLabel}
+                          >
+                            <Settings className="h-3.5 w-3.5" />
+                            <span className="sr-only">{srLabel}</span>
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  });
+                })()}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- persist a `hasLevel4Configuration` flag on slot assignments so every Level 4-enabled card (including bushing pairs) exposes the reconfigure affordance
- replace the textual configure/reconfigure button with a gear icon and surface the control alongside bushing slot summaries for easier access

## Testing
- npm run lint *(fails: numerous pre-existing lint violations in unrelated admin files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a5db6568832688fae950dc287314