### PR TITLE
Preserve level 4 data in drafts and enrich quote PDF

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -68,6 +68,200 @@ export const generateQuotePDF = async (
     console.warn('Could not fetch PDF settings:', error);
   }
 
+  const combinedQuoteFields: Record<string, any> = {
+    ...(quoteInfo?.draft_bom?.quoteFields && typeof quoteInfo.draft_bom.quoteFields === 'object'
+      ? quoteInfo.draft_bom.quoteFields
+      : {}),
+    ...(quoteInfo?.quote_fields && typeof quoteInfo.quote_fields === 'object'
+      ? quoteInfo.quote_fields
+      : {}),
+  };
+  const combinedFieldKeys = Object.keys(combinedQuoteFields);
+
+  const rackLayoutFallbackMap = new Map<string, any>();
+  if (Array.isArray(quoteInfo?.draft_bom?.rackLayouts)) {
+    quoteInfo.draft_bom.rackLayouts.forEach((entry: any) => {
+      const key = entry?.productId || entry?.partNumber;
+      if (!key) return;
+      rackLayoutFallbackMap.set(String(key), entry?.layout || entry);
+    });
+  }
+
+  const level4FallbackMap = new Map<string, any>();
+  if (Array.isArray(quoteInfo?.draft_bom?.level4Configurations)) {
+    quoteInfo.draft_bom.level4Configurations.forEach((entry: any) => {
+      const key = entry?.productId || entry?.partNumber;
+      if (!key) return;
+      level4FallbackMap.set(String(key), entry);
+    });
+  }
+
+  const normalizeSlotNumber = (value: any, fallbackIndex: number): number => {
+    if (typeof value === 'number' && !Number.isNaN(value)) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const parsed = Number.parseInt(value, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return fallbackIndex + 1;
+  };
+
+  const toSlotEntries = (slots: any[]): Array<{ slot: number; cardName: string; partNumber?: string; level4Config?: any; level4Selections?: any; }> => {
+    if (!Array.isArray(slots)) return [];
+    return slots
+      .map((slot, index) => {
+        const slotNumber = normalizeSlotNumber(slot?.slot ?? slot?.slotNumber ?? slot?.position ?? slot?.slot_index, index);
+        return {
+          slot: slotNumber,
+          cardName: slot?.cardName || slot?.displayName || slot?.name || slot?.product?.name || `Slot ${slotNumber}`,
+          partNumber: slot?.partNumber || slot?.product?.partNumber || slot?.part_number || undefined,
+          level4Config: slot?.level4Config || slot?.configuration || null,
+          level4Selections: slot?.level4Selections || slot?.selections || null,
+        };
+      })
+      .filter(entry => entry.slot !== undefined && entry.slot !== null);
+  };
+
+  const deriveRackConfiguration = (item: any): { slots: Array<{ slot: number; cardName: string; partNumber?: string; level4Config?: any; level4Selections?: any; }> } | undefined => {
+    if (!item) return undefined;
+
+    if (item.rackConfiguration && typeof item.rackConfiguration === 'object') {
+      if (Array.isArray(item.rackConfiguration.slots)) {
+        return { slots: toSlotEntries(item.rackConfiguration.slots) };
+      }
+
+      if (Array.isArray(item.rackConfiguration)) {
+        return { slots: toSlotEntries(item.rackConfiguration) };
+      }
+    }
+
+    if (Array.isArray(item.slotAssignments)) {
+      return { slots: toSlotEntries(item.slotAssignments) };
+    }
+
+    if (item.slotAssignments && typeof item.slotAssignments === 'object') {
+      const entries = Object.entries(item.slotAssignments).map(([slotKey, slotData], index) => ({
+        slot: normalizeSlotNumber(slotKey, index),
+        cardName: slotData?.displayName || slotData?.name || slotData?.product?.name || `Slot ${slotKey}`,
+        partNumber: slotData?.partNumber || slotData?.product?.partNumber || slotData?.part_number || undefined,
+        level4Config: slotData?.level4Config || null,
+        level4Selections: slotData?.level4Selections || null,
+      })).filter(entry => entry.slot !== undefined && entry.slot !== null);
+
+      if (entries.length > 0) {
+        return { slots: entries };
+      }
+    }
+
+    return undefined;
+  };
+
+  const hasConfigData = (config: any): boolean => {
+    if (!config) return false;
+    if (Array.isArray(config)) {
+      return config.length > 0;
+    }
+    if (typeof config === 'object') {
+      return Object.values(config).some(value => {
+        if (value === null || value === undefined) return false;
+        if (Array.isArray(value)) return value.length > 0;
+        if (typeof value === 'object') return Object.keys(value).length > 0;
+        return String(value).trim().length > 0;
+      });
+    }
+    return String(config).trim().length > 0;
+  };
+
+  const normalizedBomItems = bomItems.map(item => {
+    const product = item.product || {};
+    const normalizedProduct = {
+      ...product,
+      name: product.name || item.name || 'Configured Item',
+      description: product.description || item.description || '',
+      price: typeof product.price === 'number' ? product.price : (item.product?.price || item.unit_price || 0),
+    };
+
+    const partNumber = item.partNumber || item.part_number || product.partNumber || product.part_number || 'TBD';
+    const fallbackKey = product.id || partNumber || product.name;
+
+    const fallbackRackEntry = fallbackKey ? rackLayoutFallbackMap.get(String(fallbackKey)) : undefined;
+    const fallbackRack = fallbackRackEntry?.layout || fallbackRackEntry;
+    const derivedRack = deriveRackConfiguration(item) || fallbackRack;
+
+    const fallbackLevel4 = fallbackKey ? level4FallbackMap.get(String(fallbackKey)) : undefined;
+    let directLevel4 = item.level4Config || item.level4Selections || null;
+    if (!directLevel4 && fallbackLevel4?.configuration) {
+      directLevel4 = fallbackLevel4.configuration;
+    }
+
+    const slotLevel4Entries: Array<{ slot: number; cardName: string; partNumber?: string; configuration: any; }> = [];
+    const rackSlots = derivedRack?.slots || [];
+    rackSlots.forEach(slot => {
+      const configuration = slot.level4Config || slot.level4Selections;
+      if (hasConfigData(configuration)) {
+        slotLevel4Entries.push({
+          slot: slot.slot,
+          cardName: slot.cardName,
+          partNumber: slot.partNumber,
+          configuration,
+        });
+      }
+    });
+
+    if (Array.isArray(fallbackLevel4?.slots)) {
+      fallbackLevel4.slots.forEach((slot: any, index: number) => {
+        const configuration = slot?.configuration || slot?.level4Config || slot?.level4Selections;
+        if (!hasConfigData(configuration)) return;
+        slotLevel4Entries.push({
+          slot: normalizeSlotNumber(slot?.slot, index),
+          cardName: slot?.cardName || slot?.name || normalizedProduct.name,
+          partNumber: slot?.partNumber || partNumber,
+          configuration,
+        });
+      });
+    }
+
+    return {
+      ...item,
+      product: normalizedProduct,
+      enabled: item.enabled !== false,
+      partNumber,
+      rackConfiguration: derivedRack,
+      level4Config: directLevel4 || undefined,
+      slotLevel4: slotLevel4Entries,
+    };
+  });
+
+  const level4DisplayItems = normalizedBomItems.flatMap(item => {
+    const entries: Array<{ title: string; subtitle?: string; partNumber?: string; config: any; }> = [];
+
+    if (hasConfigData(item.level4Config)) {
+      entries.push({
+        title: item.product?.name || 'Configured Item',
+        subtitle: item.slot ? `Slot ${item.slot}` : undefined,
+        partNumber: item.partNumber,
+        config: item.level4Config,
+      });
+    }
+
+    if (Array.isArray(item.slotLevel4) && item.slotLevel4.length > 0) {
+      item.slotLevel4.forEach(slot => {
+        if (!hasConfigData(slot.configuration)) return;
+        entries.push({
+          title: item.product?.name || 'Configured Item',
+          subtitle: slot.slot ? `Slot ${slot.slot}` : undefined,
+          partNumber: slot.partNumber || item.partNumber,
+          config: slot.configuration,
+        });
+      });
+    }
+
+    return entries;
+  });
+
   // Calculate dates
   const createdDate = new Date();
   const expiryDate = new Date(createdDate);
@@ -127,7 +321,7 @@ export const generateQuotePDF = async (
       ${isDraft ? `
         <div class="draft-warning">
           <strong>⚠️ DRAFT</strong>
-          <p style="margin: 5px 0 0 0;">Draft is a budgetary quote, to allow PO generation, please request a formal offer with final configuration.</p>
+          <p style="margin: 5px 0 0 0;">Draft is a budgetary informative reference value; to purchase the materials, please request a formal offer with final configuration and a valid quotation ID.</p>
         </div>
       ` : ''}
 
@@ -152,40 +346,31 @@ export const generateQuotePDF = async (
         
         <!-- Dynamic PDF Fields -->
         ${quoteFieldsForPDF.map(field => {
-          let value = 'Not specified';
-          
-          if (quoteInfo.quote_fields && typeof quoteInfo.quote_fields === 'object') {
-            // Debug: Log the field we're trying to match
-            console.log(`Looking for field '${field.id}' in quote_fields:`, Object.keys(quoteInfo.quote_fields));
-            
-            // Try exact field ID match first (this is most reliable)
-            if (field.id in quoteInfo.quote_fields) {
-              value = quoteInfo.quote_fields[field.id];
-            }
-            // If not found, try common variations
-            else {
-              const fieldValue = quoteInfo.quote_fields[field.id] ||
-                                quoteInfo.quote_fields[field.id.replace(/-/g, '_')] ||
-                                quoteInfo.quote_fields[field.id.replace(/_/g, '-')] ||
-                                quoteInfo.quote_fields[field.id.toLowerCase()] ||
-                                quoteInfo.quote_fields[field.label];
-              if (fieldValue !== undefined && fieldValue !== null) {
-                value = fieldValue;
-              }
+          let value: any = 'Not specified';
+
+          if (combinedFieldKeys.length > 0) {
+            const candidates = [
+              combinedQuoteFields[field.id],
+              combinedQuoteFields[field.id?.replace(/-/g, '_')],
+              combinedQuoteFields[field.id?.replace(/_/g, '-')],
+              combinedQuoteFields[field.id?.toLowerCase?.() ?? field.id],
+              combinedQuoteFields[field.label],
+            ];
+
+            const found = candidates.find(candidate => candidate !== undefined && candidate !== null && candidate !== '');
+            if (found !== undefined) {
+              value = found;
             }
           }
-          
-          // Format value based on type
+
           if (value && typeof value === 'object') {
-            // If it's an array or object, stringify it
             value = JSON.stringify(value);
           } else if (value === null || value === undefined || value === '') {
             value = 'Not specified';
           } else {
-            // Convert to string and escape HTML
             value = String(value).replace(/</g, '&lt;').replace(/>/g, '&gt;');
           }
-          
+
           return `
             <div class="field-row">
               <div class="field-label">${field.label}:</div>
@@ -231,7 +416,7 @@ export const generateQuotePDF = async (
           </tr>
         </thead>
         <tbody>
-          ${bomItems
+          ${normalizedBomItems
             .filter(item => item.enabled)
             .map((item, index) => `
               <tr>
@@ -250,82 +435,68 @@ export const generateQuotePDF = async (
 
       ${(() => {
         // Check if any items have chassis configurations
-        const chassisItems = bomItems.filter(item => 
-          item.enabled && 
-          item.rackConfiguration && 
+        const chassisItems = normalizedBomItems.filter(item =>
+          item.enabled &&
+          item.rackConfiguration &&
           typeof item.rackConfiguration === 'object'
         );
-        
-        if (chassisItems.length === 0 && !quoteInfo.draft_bom?.rackConfiguration) {
+
+        const fallbackRackLayouts = Array.isArray(quoteInfo.draft_bom?.rackLayouts) ? quoteInfo.draft_bom.rackLayouts : [];
+
+        if (chassisItems.length === 0 && fallbackRackLayouts.length === 0 && !quoteInfo.draft_bom?.rackConfiguration) {
           return '';
         }
 
         let rackConfigHTML = '<div style="page-break-before: always; margin-top: 40px;">';
         rackConfigHTML += '<h2 style="color: #dc2626; border-bottom: 2px solid #dc2626; padding-bottom: 10px;">Rack Configuration Layout</h2>';
-        
-        // Process each chassis item
-        chassisItems.forEach((chassisItem, idx) => {
-          const config = chassisItem.rackConfiguration;
-          
+
+        const renderRackLayout = (title: string, partNumber: string | undefined, slots: any[]) => {
           rackConfigHTML += `
             <div style="margin-top: 30px; margin-bottom: 30px; background: #f8f9fa; padding: 20px; border-radius: 8px; border: 1px solid #ddd;">
-              <h3 style="color: #dc2626; margin-top: 0;">${chassisItem.product.name} - ${chassisItem.partNumber || 'TBD'}</h3>
+              <h3 style="color: #dc2626; margin-top: 0;">${title}${partNumber ? ` - ${partNumber}` : ''}</h3>
               <div style="margin-top: 15px;">`;
-          
-          // Display rack configuration as a proper table
-          if (config.slots && Array.isArray(config.slots) && config.slots.length > 0) {
+
+          if (Array.isArray(slots) && slots.length > 0) {
             rackConfigHTML += '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white;">';
             rackConfigHTML += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Slot</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Card Type</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Part Number</th></tr></thead>';
             rackConfigHTML += '<tbody>';
-            
-            config.slots.forEach((slot: any, idx: number) => {
-              const slotNumber = slot.slot || slot.slotNumber || slot.position || (idx + 1);
-              const cardName = slot.cardName || slot.name || slot.product?.name || 'Empty';
-              const partNumber = slot.partNumber || slot.part_number || slot.product?.partNumber || slot.product?.part_number || '-';
-              
+
+            slots.forEach((slot: any, idx: number) => {
+              const slotNumber = slot?.slot ?? slot?.slotNumber ?? slot?.position ?? (idx + 1);
+              const cardName = slot?.cardName || slot?.name || slot?.product?.name || 'Empty';
+              const slotPartNumber = slot?.partNumber || slot?.product?.partNumber || '-';
               const rowStyle = idx % 2 === 0 ? 'background: #f9fafb;' : 'background: white;';
               rackConfigHTML += `
                 <tr style="${rowStyle}">
                   <td style="padding: 10px; border: 1px solid #ddd; font-weight: 600;">Slot ${slotNumber}</td>
                   <td style="padding: 10px; border: 1px solid #ddd;">${cardName}</td>
-                  <td style="padding: 10px; border: 1px solid #ddd; font-family: 'Courier New', monospace; font-size: 13px;">${partNumber}</td>
+                  <td style="padding: 10px; border: 1px solid #ddd; font-family: 'Courier New', monospace; font-size: 13px;">${slotPartNumber}</td>
                 </tr>`;
             });
-            
-            rackConfigHTML += '</tbody></table>';
-          } else if (config.slotAssignments && typeof config.slotAssignments === 'object') {
-            // Alternative format: slotAssignments object
-            rackConfigHTML += '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white;">';
-            rackConfigHTML += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Slot</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Card Type</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Part Number</th></tr></thead>';
-            rackConfigHTML += '<tbody>';
-            
-            let idx = 0;
-            Object.entries(config.slotAssignments).forEach(([slotNum, cardData]: [string, any]) => {
-              if (cardData) {
-                const rowStyle = idx % 2 === 0 ? 'background: #f9fafb;' : 'background: white;';
-                const cardName = cardData.name || cardData.displayName || 'Unnamed Card';
-                const partNumber = cardData.partNumber || cardData.part_number || '-';
-                
-                rackConfigHTML += `
-                  <tr style="${rowStyle}">
-                    <td style="padding: 10px; border: 1px solid #ddd; font-weight: 600;">Slot ${slotNum}</td>
-                    <td style="padding: 10px; border: 1px solid #ddd;">${cardName}</td>
-                    <td style="padding: 10px; border: 1px solid #ddd; font-family: 'Courier New', monospace; font-size: 13px;">${partNumber}</td>
-                  </tr>`;
-                idx++;
-              }
-            });
-            
+
             rackConfigHTML += '</tbody></table>';
           } else {
-            // Fallback: No rack configuration data found
             rackConfigHTML += '<p style="color: #666; font-style: italic; padding: 15px; background: white; border-radius: 4px;">No rack configuration data available</p>';
           }
-          
+
           rackConfigHTML += '</div></div>';
+        };
+
+        // Process each chassis item
+        chassisItems.forEach(chassisItem => {
+          const config = chassisItem.rackConfiguration;
+          renderRackLayout(chassisItem.product.name, chassisItem.partNumber, config?.slots || []);
         });
-        
-        // Also check draft_bom for rack configurations
+
+        // Render fallback rack layouts stored in draft data
+        fallbackRackLayouts.forEach(layout => {
+          const slots = layout?.layout?.slots || layout?.slots;
+          if (Array.isArray(slots) && slots.length > 0) {
+            renderRackLayout(layout.productName || 'Configured Rack', layout.partNumber, slots);
+          }
+        });
+
+        // Also check draft_bom for any raw rack configuration data
         if (quoteInfo.draft_bom?.rackConfiguration) {
           rackConfigHTML += `
             <div style="margin-top: 30px; margin-bottom: 30px; background: #f8f9fa; padding: 20px; border-radius: 8px; border: 1px solid #ddd;">
@@ -339,112 +510,111 @@ export const generateQuotePDF = async (
       })()}
 
       ${(() => {
-        // Check if any items have Level 4 configurations
-        const level4Items = bomItems.filter(item => 
-          item.enabled && 
-          item.level4Config && 
-          typeof item.level4Config === 'object'
-        );
-        
-        if (level4Items.length === 0) {
+        if (level4DisplayItems.length === 0) {
           return '';
         }
 
-        let level4HTML = '<div style="margin-top: 40px; page-break-before: always;">';
-        level4HTML += '<h2 style="color: #dc2626; border-bottom: 2px solid #dc2626; padding-bottom: 10px;">Level 4 Configuration Details</h2>';
-        
-        // Group configurations by product and slot
-        level4Items.forEach((item, idx) => {
-          const config = item.level4Config;
-          const slotInfo = item.slot ? ` - Slot ${item.slot}` : '';
-          
-          level4HTML += `
-            <div style="margin-top: 25px; background: #f8f9fa; padding: 20px; border-radius: 8px; border-left: 4px solid #dc2626;">
-              <h3 style="color: #dc2626; margin-top: 0; font-size: 16px;">${item.product.name}${slotInfo}</h3>
-              <div style="margin-top: 15px; padding-left: 15px;">`;
-          
-          // Cast to any for dynamic data handling in PDF generation
+        const renderLevel4Config = (config: any): string => {
+          if (!hasConfigData(config)) {
+            return '<p style="color: #666; font-style: italic; padding: 15px; background: white; border-radius: 4px;">No configuration details available</p>';
+          }
+
           const configData = config as any;
-          
-          if (Array.isArray(configData.entries) && configData.entries.length > 0) {
-            // Display entries in a formatted table
-            level4HTML += '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white; border: 1px solid #ddd;">';
-            level4HTML += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left; width: 30%;">Input</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Configuration</th></tr></thead>';
-            level4HTML += '<tbody>';
-            
+
+          if (Array.isArray(configData?.entries) && configData.entries.length > 0) {
+            let html = '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white; border: 1px solid #ddd;">';
+            html += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left; width: 30%;">Input</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Configuration</th></tr></thead>';
+            html += '<tbody>';
+
             configData.entries.forEach((entry: any, entryIdx: number) => {
               const inputLabel = `Input #${entryIdx + 1}`;
-              // Try to get the label from the entry or look it up from options
-              let displayValue = entry.label || entry.name || 'Not configured';
-              
-              // If we only have a value ID, try to find the label from the config options
+              let displayValue = entry.label || entry.name || entry.value || 'Not configured';
+
               if (!entry.label && entry.value && configData.options) {
                 const option = configData.options.find((opt: any) => opt.id === entry.value || opt.value === entry.value);
                 if (option) {
                   displayValue = option.label || option.name || entry.value;
                 }
-              } else if (!entry.label && entry.value) {
-                displayValue = entry.value;
               }
-              
+
               const rowStyle = entryIdx % 2 === 0 ? 'background: #f9fafb;' : 'background: white;';
-              level4HTML += `
+              html += `
                 <tr style="${rowStyle}">
                   <td style="padding: 10px; border: 1px solid #ddd; font-weight: 600;">${inputLabel}</td>
                   <td style="padding: 10px; border: 1px solid #ddd;">${displayValue}</td>
                 </tr>`;
             });
-            
-            level4HTML += '</tbody></table>';
-          } else if (configData.selections && Array.isArray(configData.selections)) {
-            // Alternative format: selections array
-            level4HTML += '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white; border: 1px solid #ddd;">';
-            level4HTML += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left; width: 30%;">Input</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Configuration</th></tr></thead>';
-            level4HTML += '<tbody>';
-            
+
+            html += '</tbody></table>';
+            return html;
+          }
+
+          if (Array.isArray(configData?.selections) && configData.selections.length > 0) {
+            let html = '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white; border: 1px solid #ddd;">';
+            html += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left; width: 30%;">Input</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Configuration</th></tr></thead>';
+            html += '<tbody>';
+
             configData.selections.forEach((selection: any, idx: number) => {
               const inputLabel = `Input #${idx + 1}`;
               const displayValue = selection.label || selection.name || selection.value || 'Not configured';
               const rowStyle = idx % 2 === 0 ? 'background: #f9fafb;' : 'background: white;';
-              
-              level4HTML += `
+              html += `
                 <tr style="${rowStyle}">
                   <td style="padding: 10px; border: 1px solid #ddd; font-weight: 600;">${inputLabel}</td>
                   <td style="padding: 10px; border: 1px solid #ddd;">${displayValue}</td>
                 </tr>`;
             });
-            
-            level4HTML += '</tbody></table>';
-          } else if (typeof configData === 'object' && Object.keys(configData).length > 0) {
-            // Display as key-value pairs
-            level4HTML += '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white; border: 1px solid #ddd;">';
-            level4HTML += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left; width: 30%;">Property</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Value</th></tr></thead>';
-            level4HTML += '<tbody>';
-            
-            let idx = 0;
-            Object.entries(configData).forEach(([key, value]) => {
-              if (key !== 'id' && key !== 'level4_config_id' && key !== 'bom_item_id' && key !== 'created_at' && key !== 'updated_at') {
+
+            html += '</tbody></table>';
+            return html;
+          }
+
+          if (Array.isArray(configData)) {
+            if (configData.every((entry: any) => typeof entry === 'string' || typeof entry === 'number')) {
+              return `<ul style="margin: 10px 0 0 20px; color: #333;">${configData.map((entry: any) => `<li>${String(entry).replace(/</g, '&lt;').replace(/>/g, '&gt;')}</li>`).join('')}</ul>`;
+            }
+            return `<pre style="white-space: pre-wrap; font-family: monospace; font-size: 12px; background: white; padding: 10px; border-radius: 4px;">${JSON.stringify(configData, null, 2)}</pre>`;
+          }
+
+          if (configData && typeof configData === 'object') {
+            const entries = Object.entries(configData).filter(([key]) => !['id', 'level4_config_id', 'bom_item_id', 'created_at', 'updated_at', 'options'].includes(key));
+            if (entries.length > 0) {
+              let html = '<table style="width: 100%; border-collapse: collapse; margin-top: 10px; background: white; border: 1px solid #ddd;">';
+              html += '<thead><tr style="background: #dc2626; color: white;"><th style="padding: 10px; border: 1px solid #ddd; text-align: left; width: 30%;">Property</th><th style="padding: 10px; border: 1px solid #ddd; text-align: left;">Value</th></tr></thead>';
+              html += '<tbody>';
+
+              entries.forEach(([key, value], idx) => {
                 const displayKey = key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
                 const displayValue = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
                 const rowStyle = idx % 2 === 0 ? 'background: #f9fafb;' : 'background: white;';
-                
-                level4HTML += `
+                html += `
                   <tr style="${rowStyle}">
                     <td style="padding: 10px; border: 1px solid #ddd; font-weight: 600;">${displayKey}</td>
-                    <td style="padding: 10px; border: 1px solid #ddd; white-space: pre-wrap; font-family: 'Courier New', monospace; font-size: 12px;">${displayValue}</td>
+                    <td style="padding: 10px; border: 1px solid #ddd; white-space: pre-wrap; font-family: 'Courier New', monospace; font-size: 12px;">${displayValue.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</td>
                   </tr>`;
-                idx++;
-              }
-            });
-            
-            level4HTML += '</tbody></table>';
-          } else {
-            level4HTML += '<p style="color: #666; font-style: italic; padding: 15px; background: white; border-radius: 4px;">No configuration details available</p>';
+              });
+
+              html += '</tbody></table>';
+              return html;
+            }
           }
-          
-          level4HTML += '</div></div>';
+
+          return `<p style="color: #333; padding: 10px; background: white; border-radius: 4px;">${String(configData).replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>`;
+        };
+
+        let level4HTML = '<div style="margin-top: 40px; page-break-before: always;">';
+        level4HTML += '<h2 style="color: #dc2626; border-bottom: 2px solid #dc2626; padding-bottom: 10px;">Level 4 Configuration Details</h2>';
+
+        level4DisplayItems.forEach(entry => {
+          level4HTML += `
+            <div style="margin-top: 25px; background: #f8f9fa; padding: 20px; border-radius: 8px; border-left: 4px solid #dc2626;">
+              <h3 style="color: #dc2626; margin-top: 0; font-size: 16px;">${entry.title}${entry.subtitle ? ` - ${entry.subtitle}` : ''}${entry.partNumber ? ` (${entry.partNumber})` : ''}</h3>
+              <div style="margin-top: 15px; padding-left: 15px;">
+                ${renderLevel4Config(entry.config)}
+              </div>
+            </div>`;
         });
-        
+
         level4HTML += '</div>';
         return level4HTML;
       })()}

--- a/src/utils/slotAssignmentUtils.ts
+++ b/src/utils/slotAssignmentUtils.ts
@@ -1,0 +1,119 @@
+import type { Level3Product } from '@/types/product';
+
+export interface SerializedSlotAssignment {
+  slot: number;
+  productId?: string;
+  name?: string;
+  displayName?: string;
+  partNumber?: string;
+  hasLevel4Configuration?: boolean;
+  level4BomItemId?: string;
+  level4TempQuoteId?: string;
+  level4Config?: any;
+  level4Selections?: any;
+  isBushingPrimary?: boolean;
+  isBushingSecondary?: boolean;
+  bushingPairSlot?: number | null;
+}
+
+const safeNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+};
+
+export const serializeSlotAssignments = (
+  assignments: Record<number, Level3Product>
+): SerializedSlotAssignment[] => {
+  return Object.entries(assignments).map(([slotKey, card]) => {
+    const slotNumber = Number.parseInt(slotKey, 10);
+    const extended = card as Level3Product & Record<string, any>;
+
+    return {
+      slot: Number.isNaN(slotNumber) ? 0 : slotNumber,
+      productId: card.id,
+      name: card.name,
+      displayName: extended.displayName || card.name,
+      partNumber: extended.partNumber || card.partNumber,
+      hasLevel4Configuration:
+        Boolean(extended.hasLevel4Configuration) ||
+        Boolean(extended.has_level4) ||
+        Boolean(extended.requires_level4_config),
+      level4BomItemId: extended.level4BomItemId,
+      level4TempQuoteId: extended.level4TempQuoteId,
+      level4Config: extended.level4Config ?? null,
+      level4Selections: extended.level4Selections ?? null,
+      isBushingPrimary: Boolean(extended.isBushingPrimary),
+      isBushingSecondary: Boolean(extended.isBushingSecondary),
+      bushingPairSlot:
+        safeNumber(extended.bushingPairSlot) ?? safeNumber(extended.bushing_pair_slot) ?? null,
+    };
+  });
+};
+
+export const deserializeSlotAssignments = (
+  stored?: SerializedSlotAssignment[] | null
+): Record<number, Level3Product & Record<string, any>> | undefined => {
+  if (!Array.isArray(stored) || stored.length === 0) {
+    return undefined;
+  }
+
+  return stored.reduce<Record<number, Level3Product & Record<string, any>>>((acc, entry) => {
+    const slotNumber = safeNumber(entry.slot);
+    if (slotNumber === undefined) {
+      return acc;
+    }
+
+    acc[slotNumber] = {
+      id: entry.productId || `slot-${slotNumber}`,
+      name: entry.name || entry.displayName || `Slot ${slotNumber} Card`,
+      displayName: entry.displayName || entry.name || `Slot ${slotNumber} Card`,
+      description: '',
+      price: 0,
+      enabled: true,
+      parent_product_id: '',
+      product_level: 3,
+      partNumber: entry.partNumber,
+      has_level4: entry.hasLevel4Configuration ?? false,
+      requires_level4_config: entry.hasLevel4Configuration ?? false,
+      level4Config: entry.level4Config ?? null,
+      level4Selections: entry.level4Selections ?? null,
+      level4BomItemId: entry.level4BomItemId,
+      level4TempQuoteId: entry.level4TempQuoteId,
+      isBushingPrimary: entry.isBushingPrimary ?? false,
+      isBushingSecondary: entry.isBushingSecondary ?? false,
+      bushingPairSlot: entry.bushingPairSlot ?? undefined,
+    } as Level3Product & Record<string, any>;
+
+    return acc;
+  }, {});
+};
+
+export const buildRackLayoutFromAssignments = (
+  assignments?: SerializedSlotAssignment[] | null
+) => {
+  if (!Array.isArray(assignments) || assignments.length === 0) {
+    return undefined;
+  }
+
+  return {
+    slots: assignments
+      .slice()
+      .sort((a, b) => (safeNumber(a.slot) ?? 0) - (safeNumber(b.slot) ?? 0))
+      .map(slot => ({
+        slot: safeNumber(slot.slot) ?? undefined,
+        cardName: slot.displayName || slot.name,
+        partNumber: slot.partNumber,
+        level4Config: slot.level4Config ?? null,
+        level4Selections: slot.level4Selections ?? null,
+        level4BomItemId: slot.level4BomItemId,
+      })),
+  };
+};


### PR DESCRIPTION
## Summary
- add slot assignment serialization utilities and persist rack/level 4 data with draft BOM items
- restore slot, rack, and level 4 configuration details when reloading quotes and generating PDFs
- standardize draft quote display in the manager and expose the saved rack layouts and slot configurations in the PDF output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe3e66b108326b513ccaf537446d6