### PR TITLE
Include draft metadata in BOM PDF generation

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -2466,6 +2466,8 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
               isDraftMode={isDraftMode}
               currentQuoteId={currentQuoteId}
               draftName={currentQuote?.status === 'draft' ? currentQuote?.customer_name : null}
+              quoteFields={quoteFields}
+              quoteMetadata={currentQuote}
               discountPercentage={discountPercentage}
               discountJustification={discountJustification}
               onDiscountChange={(percentage, justification) => {


### PR DESCRIPTION
## Summary
- pass the current quote field values and metadata from the builder into the enhanced BOM display
- enrich the generated quote info payload with merged quote fields, existing identifiers, and draft status when appropriate
- show a friendlier draft badge caption instead of the raw UUID in the BOM panel

## Testing
- npm run lint *(fails: existing repository lint errors for unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbea746b4c832696c7f2c15088e188