### PR TITLE
Enable Level 3 part number editing

### DIFF
--- a/src/components/admin/product-forms/CardForm.tsx
+++ b/src/components/admin/product-forms/CardForm.tsx
@@ -27,7 +27,8 @@ const CardForm = ({ onSubmit, level2Products, initialData }: CardFormProps) => {
     has_level4: (initialData as any)?.has_level4 || false,
     specifications: initialData?.specifications || {},
     product_level: 3 as const,
-    image: initialData?.image || ''
+    image: initialData?.image || '',
+    partNumber: initialData?.partNumber || ''
   });
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -46,7 +47,8 @@ const CardForm = ({ onSubmit, level2Products, initialData }: CardFormProps) => {
       has_level4: (formData as any).has_level4,
       specifications: formData.specifications,
       product_level: 3,
-      image: formData.image || undefined
+      image: formData.image || undefined,
+      partNumber: formData.partNumber?.trim() ? formData.partNumber.trim() : undefined
     };
     onSubmit(newCard);
   };
@@ -156,10 +158,14 @@ const CardForm = ({ onSubmit, level2Products, initialData }: CardFormProps) => {
       </div>
 
       <div>
-        <Label className="text-foreground">Part Number</Label>
-        <div className="text-sm text-gray-400">
-          Part numbers are configured under Products → Part Numbers.
-        </div>
+        <Label htmlFor="partNumber" className="text-foreground">Part Number</Label>
+        <Input
+          id="partNumber"
+          value={formData.partNumber}
+          onChange={(e) => setFormData({ ...formData, partNumber: e.target.value })}
+          className="bg-background border-input text-foreground"
+          placeholder="e.g., ANA-16CH-001"
+        />
       </div>
 
       {/* Specifications Section */}

--- a/src/components/admin/product-forms/Level2OptionForm.tsx
+++ b/src/components/admin/product-forms/Level2OptionForm.tsx
@@ -24,14 +24,18 @@ const Level2OptionForm = ({ onSubmit, level1Products, initialData }: Level2Optio
     cost: initialData?.cost || 0,
     enabled: initialData?.enabled ?? true,
     specifications: initialData?.specifications || {},
-    
+
     image: initialData?.image || '',
-    productInfoUrl: initialData?.productInfoUrl || ''
+    productInfoUrl: initialData?.productInfoUrl || '',
+    partNumber: initialData?.partNumber || ''
   });
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit(formData);
+    onSubmit({
+      ...formData,
+      partNumber: formData.partNumber?.trim() ? formData.partNumber.trim() : undefined
+    });
   };
 
   const handleSpecificationChange = (key: string, value: any) => {
@@ -139,10 +143,14 @@ const Level2OptionForm = ({ onSubmit, level1Products, initialData }: Level2Optio
           <h3 className="text-lg font-medium text-white mb-4">Product Details</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <Label className="text-white">Part Number</Label>
-              <div className="text-sm text-gray-400">
-                Part numbers are configured under Products → Part Numbers.
-              </div>
+              <Label htmlFor="partNumber" className="text-white">Part Number</Label>
+              <Input
+                id="partNumber"
+                value={formData.partNumber}
+                onChange={(e) => setFormData({ ...formData, partNumber: e.target.value })}
+                className="bg-gray-900 border-gray-600 text-white"
+                placeholder="e.g., ANA-16CH-001"
+              />
             </div>
             <div>
               <Label htmlFor="productInfoUrl" className="text-white">Product Info URL</Label>

--- a/src/components/admin/product-lists/Level3ProductList.tsx
+++ b/src/components/admin/product-lists/Level3ProductList.tsx
@@ -42,7 +42,8 @@ export const Level3ProductList: React.FC<Level3ProductListProps> = ({
       price: product.price,
       cost: product.cost || 0,
       enabled: product.enabled !== false,
-      has_level4: (product as any).has_level4 || false
+      has_level4: (product as any).has_level4 || false,
+      partNumber: product.partNumber || ''
     });
   };
 
@@ -60,10 +61,15 @@ export const Level3ProductList: React.FC<Level3ProductListProps> = ({
 
   const handleEditSave = async (productId: string) => {
     if (!editingProduct) return;
-    
+
     try {
       setIsSaving(true);
-      await productDataService.updateLevel3Product(productId, editFormData);
+      await productDataService.updateLevel3Product(productId, {
+        ...editFormData,
+        partNumber: editFormData.partNumber !== undefined
+          ? editFormData.partNumber.trim()
+          : undefined
+      });
 
       onProductUpdate();
       setEditingProduct(null);
@@ -209,6 +215,16 @@ export const Level3ProductList: React.FC<Level3ProductListProps> = ({
                         className="bg-white border-gray-300 text-gray-900"
                       />
                     </div>
+                    <div>
+                      <Label htmlFor={`partNumber-${product.id}`} className="text-gray-700">Part Number</Label>
+                      <Input
+                        id={`partNumber-${product.id}`}
+                        value={editFormData.partNumber || ''}
+                        onChange={(e) => setEditFormData(prev => ({ ...prev, partNumber: e.target.value }))}
+                        placeholder="e.g., ANA-16CH-001"
+                        className="bg-white border-gray-300 text-gray-900"
+                      />
+                    </div>
                       <div className="flex items-center space-x-2">
                         <Switch
                           id={`enabled-${product.id}`}
@@ -348,6 +364,10 @@ export const Level3ProductList: React.FC<Level3ProductListProps> = ({
                     <div>
                       <span className="text-gray-500">Cost:</span>
                       <span className="text-gray-900 font-medium ml-2">${(product.cost || 0).toLocaleString()}</span>
+                    </div>
+                    <div>
+                      <span className="text-gray-500">Part Number:</span>
+                      <span className="text-gray-900 font-medium ml-2">{product.partNumber || '—'}</span>
                     </div>
                   </div>
                   {parentFilter !== 'all' && (


### PR DESCRIPTION
## Summary
- add part number fields to the Level 3 card/option forms and expose values in the Level 3 product list
- persist Level 3 part number changes by mapping the UI values to the Supabase schema and cache

## Testing
- npm run lint *(fails: existing lint errors about `any` usage in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dda24d87e08326a1b7d71d25989081