### PR TITLE
Restore chassis configuration when reopening draft quotes

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -361,7 +361,48 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
           // Use stored values from draft_bom, fallback to unit_price/unit_cost, then fetch if needed
           let price = item.product?.price || item.unit_price || item.total_price || 0;
           let cost = item.product?.cost || item.unit_cost || item.total_cost || 0;
-          
+
+          const rawConfiguration =
+            (typeof item.configuration_data === 'object' && item.configuration_data) ||
+            (typeof item.configurationData === 'object' && item.configurationData) ||
+            (typeof item.product?.configuration_data === 'object' && item.product.configuration_data) ||
+            {};
+
+          const productSource = (typeof item.product === 'object' && item.product) || {};
+          const configurationData = { ...productSource, ...rawConfiguration };
+
+          const rawSlotAssignments =
+            item.slotAssignments ||
+            rawConfiguration.slotAssignments ||
+            configurationData.slotAssignments;
+
+          const normalizedSlotAssignments: SerializedSlotAssignment[] | undefined = Array.isArray(rawSlotAssignments)
+            ? rawSlotAssignments
+            : rawSlotAssignments && typeof rawSlotAssignments === 'object'
+              ? Object.entries(rawSlotAssignments).map(([slotKey, cardData]) => {
+                  const slotNumber = Number.parseInt(slotKey, 10);
+                  const card = (cardData || {}) as Record<string, any>;
+                  return {
+                    slot: Number.isNaN(slotNumber) ? 0 : slotNumber,
+                    productId: card.id,
+                    name: card.name,
+                    displayName: card.displayName,
+                    partNumber: card.partNumber,
+                    hasLevel4Configuration:
+                      Boolean(card.hasLevel4Configuration) ||
+                      Boolean(card.has_level4) ||
+                      Boolean(card.requires_level4_config),
+                    level4BomItemId: card.level4BomItemId,
+                    level4TempQuoteId: card.level4TempQuoteId,
+                    level4Config: card.level4Config ?? null,
+                    level4Selections: card.level4Selections ?? null,
+                    isBushingPrimary: card.isBushingPrimary ?? false,
+                    isBushingSecondary: card.isBushingSecondary ?? false,
+                    bushingPairSlot: card.bushingPairSlot ?? card.bushing_pair_slot ?? null,
+                  } as SerializedSlotAssignment;
+                })
+              : undefined;
+
           // If price or cost is 0, fetch fresh product data
           if ((price === 0 || cost === 0) && (item.productId || item.product_id)) {
             try {
@@ -380,11 +421,27 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
             }
           }
           
-          const storedSlotAssignments = item.slotAssignments as SerializedSlotAssignment[] | undefined;
-          const slotAssignmentsMap = deserializeSlotAssignments(storedSlotAssignments);
-          const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(storedSlotAssignments);
-          const level4Config = item.level4Config ?? null;
-          const level4Selections = item.level4Selections ?? null;
+          const slotAssignmentsMap = deserializeSlotAssignments(normalizedSlotAssignments);
+          const rackLayout =
+            item.rackConfiguration ||
+            rawConfiguration.rackConfiguration ||
+            configurationData.rackConfiguration ||
+            buildRackLayoutFromAssignments(normalizedSlotAssignments);
+          const level4Config =
+            item.level4Config ??
+            rawConfiguration.level4Config ??
+            configurationData.level4Config ??
+            null;
+          const level4Selections =
+            item.level4Selections ??
+            rawConfiguration.level4Selections ??
+            configurationData.level4Selections ??
+            null;
+          const configuration =
+            item.configuration ??
+            rawConfiguration.configuration ??
+            configurationData.configuration ??
+            null;
 
           return {
             id: item.id || crypto.randomUUID(),
@@ -392,9 +449,10 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
               id: item.productId || item.product_id || item.product?.id,
               name: item.name || item.product?.name,
               partNumber: item.partNumber || item.part_number || item.product?.partNumber,
+              description: item.description || item.product?.description || configurationData.description || '',
+              ...configurationData,
               price,
               cost,
-              description: item.description || item.product?.description || ''
             },
             quantity: item.quantity || 1,
             enabled: item.enabled !== false,
@@ -405,8 +463,11 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
             priceHistory: item.priceHistory || [],
             slotAssignments: slotAssignmentsMap,
             rackConfiguration: rackLayout,
+            configuration: configuration || undefined,
             level4Config: level4Config || undefined,
             level4Selections: level4Selections || undefined,
+            displayName: item.displayName || configurationData.displayName || configurationData.name,
+            isAccessory: item.isAccessory ?? configurationData.isAccessory,
           };
         }));
         


### PR DESCRIPTION
## Summary
- normalize draft BOM configuration data to handle legacy slot assignment formats when loading quotes
- restore saved rack layouts, level 4 selections, and chassis metadata so editing draft chassis shows prior configuration

## Testing
- npm run lint *(fails: existing lint violations across admin components and utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb15c8d8883269b77c33c2df0dcc3