### PR TITLE
Fix syntax error in BOMBuilder draft load logic

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -579,10 +579,8 @@ if (
       } as BOMItem;
     }),
   );
-}
-        
-        console.log(`Loaded ${loadedItems.length} items from draft_bom`);
-      } else {
+  console.log(`Loaded ${loadedItems.length} items from draft_bom`);
+} else {
         console.log('Loading BOM data from bom_items table');
         // Load BOM items with Level 4 configurations from database table
         const { data: bomData, error: bomError } = await supabase


### PR DESCRIPTION
## Summary
- move the draft BOM console log inside the draft_bom branch so the `else` clause attaches correctly
- ensure the `else` branch executes when no draft BOM is present, preventing build-time syntax errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddc0ef8b3483269cbbd86e1d088907