### PR TITLE
Restore slot metadata when rebuilding rack layout fallbacks

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -57,9 +57,13 @@ const convertRackLayoutToAssignments = (
       slotNumber?: number | null;
       cardName?: string | null;
       partNumber?: string | null;
-      product?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
+      product?: { id?: string | null; name?: string | null; displayName?: string | null; partNumber?: string | null; part_number?: string | null } | null;
       level4Config?: any;
       level4Selections?: any;
+      productId?: string | null;
+      product_id?: string | null;
+      cardId?: string | null;
+      card_id?: string | null;
     }>;
   }
 ): Record<number, Level3Product & Record<string, any>> | undefined => {
@@ -78,10 +82,64 @@ const convertRackLayoutToAssignments = (
       return acc;
     }
 
-    const name = slot.cardName || slot.product?.displayName || slot.product?.name || `Slot ${position} Card`;
+    const rawSlot = slot as Record<string, any>;
+    const cardRecord = (rawSlot.card as Record<string, any> | undefined) || undefined;
+    const nestedProduct =
+      (cardRecord?.product as Record<string, any> | undefined) ||
+      (cardRecord?.card as Record<string, any> | undefined) ||
+      (cardRecord?.level3Product as Record<string, any> | undefined) ||
+      undefined;
+
+    const productSource =
+      (slot.product as Record<string, any> | null | undefined) ||
+      cardRecord ||
+      nestedProduct ||
+      undefined;
+
+    const productId =
+      rawSlot.productId ||
+      rawSlot.product_id ||
+      rawSlot.cardId ||
+      rawSlot.card_id ||
+      rawSlot.level3ProductId ||
+      rawSlot.level3_product_id ||
+      cardRecord?.id ||
+      cardRecord?.productId ||
+      cardRecord?.product_id ||
+      cardRecord?.cardId ||
+      cardRecord?.card_id ||
+      cardRecord?.level3ProductId ||
+      cardRecord?.level3_product_id ||
+      nestedProduct?.id ||
+      nestedProduct?.productId ||
+      nestedProduct?.product_id ||
+      productSource?.id ||
+      undefined;
+
+    const name =
+      slot.cardName ||
+      productSource?.displayName ||
+      productSource?.name ||
+      `Slot ${position} Card`;
+
+    const partNumber =
+      slot.partNumber ||
+      rawSlot.part_number ||
+      rawSlot.cardPartNumber ||
+      rawSlot.card_part_number ||
+      cardRecord?.partNumber ||
+      cardRecord?.part_number ||
+      cardRecord?.cardPartNumber ||
+      cardRecord?.card_part_number ||
+      (typeof cardRecord?.pn === 'string' ? cardRecord?.pn : undefined) ||
+      nestedProduct?.partNumber ||
+      nestedProduct?.part_number ||
+      productSource?.partNumber ||
+      productSource?.part_number ||
+      undefined;
 
     acc[position] = {
-      id: slot.product?.id || `slot-${position}`,
+      id: productId || `slot-${position}`,
       name,
       displayName: name,
       description: '',
@@ -89,7 +147,7 @@ const convertRackLayoutToAssignments = (
       enabled: true,
       parent_product_id: '',
       product_level: 3,
-      partNumber: slot.partNumber || undefined,
+      partNumber,
       level4Config: slot.level4Config ?? null,
       level4Selections: slot.level4Selections ?? null,
     } as Level3Product & Record<string, any>;
@@ -459,12 +517,37 @@ if (
         ? Object.entries(rawSlotAssignments).map(([slotKey, cardData]) => {
             const slotNumber = Number.parseInt(slotKey, 10);
             const card = (cardData || {}) as Record<string, any>;
+
+            const productSource = (card.product || card.card || {}) as Record<string, any>;
+            const productId =
+              card.id ||
+              card.productId ||
+              card.product_id ||
+              card.cardId ||
+              card.card_id ||
+              card.level3ProductId ||
+              card.level3_product_id ||
+              productSource.id;
+
+            const partNumber =
+              card.partNumber ||
+              card.part_number ||
+              productSource.partNumber ||
+              productSource.part_number ||
+              (typeof card.pn === 'string' ? card.pn : undefined);
+
+            const displayName =
+              card.displayName ||
+              card.name ||
+              productSource.displayName ||
+              productSource.name;
+
             return {
               slot: Number.isNaN(slotNumber) ? 0 : slotNumber,
-              productId: card.id,
-              name: card.name,
-              displayName: card.displayName,
-              partNumber: card.partNumber,
+              productId: productId,
+              name: card.name || productSource.name,
+              displayName,
+              partNumber,
               hasLevel4Configuration:
                 Boolean(card.hasLevel4Configuration) ||
                 Boolean(card.has_level4) ||
@@ -579,10 +662,8 @@ if (
       } as BOMItem;
     }),
   );
-}
-        
-        console.log(`Loaded ${loadedItems.length} items from draft_bom`);
-      } else {
+  console.log(`Loaded ${loadedItems.length} items from draft_bom`);
+} else {
         console.log('Loading BOM data from bom_items table');
         // Load BOM items with Level 4 configurations from database table
         const { data: bomData, error: bomError } = await supabase


### PR DESCRIPTION
## Summary
- expand rack layout fallback parsing to recover nested card/product identifiers and part numbers
- ensure reconstructed slot assignments keep product ids needed for chassis part number synthesis

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddc0ef8b3483269cbbd86e1d088907