### PR TITLE
Preserve chassis part numbers when editing draft BOMs

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -57,9 +57,13 @@ const convertRackLayoutToAssignments = (
       slotNumber?: number | null;
       cardName?: string | null;
       partNumber?: string | null;
-      product?: { id?: string | null; name?: string | null; displayName?: string | null } | null;
+      product?: { id?: string | null; name?: string | null; displayName?: string | null; partNumber?: string | null; part_number?: string | null } | null;
       level4Config?: any;
       level4Selections?: any;
+      productId?: string | null;
+      product_id?: string | null;
+      cardId?: string | null;
+      card_id?: string | null;
     }>;
   }
 ): Record<number, Level3Product & Record<string, any>> | undefined => {
@@ -78,10 +82,64 @@ const convertRackLayoutToAssignments = (
       return acc;
     }
 
-    const name = slot.cardName || slot.product?.displayName || slot.product?.name || `Slot ${position} Card`;
+    const rawSlot = slot as Record<string, any>;
+    const cardRecord = (rawSlot.card as Record<string, any> | undefined) || undefined;
+    const nestedProduct =
+      (cardRecord?.product as Record<string, any> | undefined) ||
+      (cardRecord?.card as Record<string, any> | undefined) ||
+      (cardRecord?.level3Product as Record<string, any> | undefined) ||
+      undefined;
+
+    const productSource =
+      (slot.product as Record<string, any> | null | undefined) ||
+      cardRecord ||
+      nestedProduct ||
+      undefined;
+
+    const productId =
+      rawSlot.productId ||
+      rawSlot.product_id ||
+      rawSlot.cardId ||
+      rawSlot.card_id ||
+      rawSlot.level3ProductId ||
+      rawSlot.level3_product_id ||
+      cardRecord?.id ||
+      cardRecord?.productId ||
+      cardRecord?.product_id ||
+      cardRecord?.cardId ||
+      cardRecord?.card_id ||
+      cardRecord?.level3ProductId ||
+      cardRecord?.level3_product_id ||
+      nestedProduct?.id ||
+      nestedProduct?.productId ||
+      nestedProduct?.product_id ||
+      productSource?.id ||
+      undefined;
+
+    const name =
+      slot.cardName ||
+      productSource?.displayName ||
+      productSource?.name ||
+      `Slot ${position} Card`;
+
+    const partNumber =
+      slot.partNumber ||
+      rawSlot.part_number ||
+      rawSlot.cardPartNumber ||
+      rawSlot.card_part_number ||
+      cardRecord?.partNumber ||
+      cardRecord?.part_number ||
+      cardRecord?.cardPartNumber ||
+      cardRecord?.card_part_number ||
+      (typeof cardRecord?.pn === 'string' ? cardRecord?.pn : undefined) ||
+      nestedProduct?.partNumber ||
+      nestedProduct?.part_number ||
+      productSource?.partNumber ||
+      productSource?.part_number ||
+      undefined;
 
     acc[position] = {
-      id: slot.product?.id || `slot-${position}`,
+      id: productId || `slot-${position}`,
       name,
       displayName: name,
       description: '',
@@ -89,13 +147,104 @@ const convertRackLayoutToAssignments = (
       enabled: true,
       parent_product_id: '',
       product_level: 3,
-      partNumber: slot.partNumber || undefined,
+      partNumber,
       level4Config: slot.level4Config ?? null,
       level4Selections: slot.level4Selections ?? null,
     } as Level3Product & Record<string, any>;
 
     return acc;
   }, {});
+};
+
+const deepClone = <T,>(value: T): T => {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (error) {
+    console.warn('Failed to deep clone value, returning original reference.', error);
+    return value;
+  }
+};
+
+const resolvePartNumberContext = (...candidates: Array<any>) => {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+
+    const container =
+      typeof candidate === 'object' && candidate !== null && 'partNumberContext' in candidate
+        ? (candidate as Record<string, any>).partNumberContext
+        : candidate;
+
+    if (container && typeof container === 'object') {
+      const context = container as Record<string, any>;
+      if ('pnConfig' in context || 'codeMap' in context) {
+        return context;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const slotSignature = (card?: Level3Product & Record<string, any>) => {
+  if (!card) {
+    return '';
+  }
+
+  const productId =
+    (card as any).productId ||
+    (card as any).product_id ||
+    (card as any).cardId ||
+    (card as any).card_id ||
+    card.id ||
+    '';
+
+  const partNumber =
+    (card as any).partNumber ||
+    (card as any).part_number ||
+    card.partNumber ||
+    '';
+
+  return `${productId}::${partNumber}`;
+};
+
+const haveSlotAssignmentsChanged = (
+  originalAssignments?: Record<number, Level3Product & Record<string, any>>,
+  currentAssignments?: Record<number, Level3Product & Record<string, any>>
+) => {
+  const original = originalAssignments || {};
+  const current = currentAssignments || {};
+
+  const allSlots = new Set([
+    ...Object.keys(original).map(slot => Number.parseInt(slot, 10)),
+    ...Object.keys(current).map(slot => Number.parseInt(slot, 10)),
+  ]);
+
+  if (allSlots.size === 0) {
+    return false;
+  }
+
+  for (const slot of allSlots) {
+    const originalCard = original[slot];
+    const currentCard = current[slot];
+
+    if (!originalCard && !currentCard) {
+      continue;
+    }
+
+    if (!originalCard || !currentCard) {
+      return true;
+    }
+
+    if (slotSignature(originalCard) !== slotSignature(currentCard)) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, mode = 'new' }: BOMBuilderProps) => {
@@ -437,6 +586,20 @@ if (
           : undefined;
 
       const mergedConfigurationData = { ...productSource, ...rawConfiguration };
+      const mergedPartNumberContext = (mergedConfigurationData as any)?.partNumberContext;
+      if (mergedPartNumberContext) {
+        delete (mergedConfigurationData as any).partNumberContext;
+      }
+
+      const partNumberContext = resolvePartNumberContext(
+        item.partNumberContext,
+        rawConfiguration.partNumberContext,
+        nestedConfiguration?.partNumberContext,
+        mergedPartNumberContext,
+        productSource,
+        item.configuration_data,
+        item.configuration
+      );
 
       // Slot assignments: accept array or object maps; check multiple possible fields
       const rawSlotAssignments =
@@ -459,12 +622,37 @@ if (
         ? Object.entries(rawSlotAssignments).map(([slotKey, cardData]) => {
             const slotNumber = Number.parseInt(slotKey, 10);
             const card = (cardData || {}) as Record<string, any>;
+
+            const productSource = (card.product || card.card || {}) as Record<string, any>;
+            const productId =
+              card.id ||
+              card.productId ||
+              card.product_id ||
+              card.cardId ||
+              card.card_id ||
+              card.level3ProductId ||
+              card.level3_product_id ||
+              productSource.id;
+
+            const partNumber =
+              card.partNumber ||
+              card.part_number ||
+              productSource.partNumber ||
+              productSource.part_number ||
+              (typeof card.pn === 'string' ? card.pn : undefined);
+
+            const displayName =
+              card.displayName ||
+              card.name ||
+              productSource.displayName ||
+              productSource.name;
+
             return {
               slot: Number.isNaN(slotNumber) ? 0 : slotNumber,
-              productId: card.id,
-              name: card.name,
-              displayName: card.displayName,
-              partNumber: card.partNumber,
+              productId: productId,
+              name: card.name || productSource.name,
+              displayName,
+              partNumber,
               hasLevel4Configuration:
                 Boolean(card.hasLevel4Configuration) ||
                 Boolean(card.has_level4) ||
@@ -576,13 +764,12 @@ if (
           (mergedConfigurationData as any)?.displayName ||
           (mergedConfigurationData as any)?.name,
         isAccessory: item.isAccessory ?? (mergedConfigurationData as any)?.isAccessory,
+        partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
       } as BOMItem;
     }),
   );
-}
-        
-        console.log(`Loaded ${loadedItems.length} items from draft_bom`);
-      } else {
+  console.log(`Loaded ${loadedItems.length} items from draft_bom`);
+} else {
         console.log('Loading BOM data from bom_items table');
         // Load BOM items with Level 4 configurations from database table
         const { data: bomData, error: bomError } = await supabase
@@ -612,6 +799,16 @@ if (
         // Convert BOM items back to local format with proper structure
         loadedItems = (bomData || []).map(item => {
           const configData = item.configuration_data || {};
+          const embeddedPartNumberContext = (configData as any)?.partNumberContext;
+          if (embeddedPartNumberContext) {
+            delete (configData as any).partNumberContext;
+          }
+
+          const partNumberContext = resolvePartNumberContext(
+            item.partNumberContext,
+            embeddedPartNumberContext,
+            configData
+          );
           const storedSlotAssignments = configData.slotAssignments as SerializedSlotAssignment[] | undefined;
           const slotAssignmentsMap = deserializeSlotAssignments(storedSlotAssignments);
           const rackLayout = configData.rackConfiguration || buildRackLayoutFromAssignments(storedSlotAssignments);
@@ -641,6 +838,7 @@ if (
             rackConfiguration: rackLayout,
             level4Config: mergedLevel4 || undefined,
             level4Selections: configData.level4Selections || undefined,
+            partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
           };
         });
       }
@@ -863,12 +1061,16 @@ if (
           }
 
           const serializedSlots = item.slotAssignments ? serializeSlotAssignments(item.slotAssignments) : undefined;
-          const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(serializedSlots);
+        const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(serializedSlots);
 
-          if (rackLayout?.slots && rackLayout.slots.length > 0) {
-            rackLayoutSummaries.push({
-              productId: item.product.id,
-              productName: item.product.name,
+        const partNumberContext =
+          item.partNumberContext ||
+          resolvePartNumberContext(item.configuration, item.product);
+
+        if (rackLayout?.slots && rackLayout.slots.length > 0) {
+          rackLayoutSummaries.push({
+            productId: item.product.id,
+            productName: item.product.name,
               partNumber: item.partNumber || item.product.partNumber,
               layout: rackLayout,
             });
@@ -913,13 +1115,15 @@ if (
             configuration_data: {
               ...item.product,
               price,
-              cost
+              cost,
+              partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
             },
             product_type: 'standard',
             slotAssignments: serializedSlots,
             rackConfiguration: rackLayout,
             level4Config: item.level4Config || null,
             level4Selections: item.level4Selections || null,
+            partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
           };
         }),
         quoteFields,
@@ -1760,14 +1964,22 @@ if (
     if (!selectedChassis) return;
 
     // Generate the part number for this configuration
-    const partNumber = buildQTMSPartNumber({ 
-      chassis: selectedChassis, 
-      slotAssignments, 
-      hasRemoteDisplay, 
-      pnConfig, 
-      codeMap, 
-      includeSuffix: true 
+    const partNumber = buildQTMSPartNumber({
+      chassis: selectedChassis,
+      slotAssignments,
+      hasRemoteDisplay,
+      pnConfig,
+      codeMap,
+      includeSuffix: true
     });
+
+    const partNumberContext =
+      pnConfig || (codeMap && Object.keys(codeMap).length > 0)
+        ? {
+            pnConfig: pnConfig ? deepClone(pnConfig) : null,
+            codeMap: codeMap ? deepClone(codeMap) : {},
+          }
+        : undefined;
 
     // Create a new BOM item for the chassis with its configuration
     const newItem: BOMItem = {
@@ -1784,7 +1996,8 @@ if (
       slotAssignments: { ...slotAssignments },
       configuration: {
         hasRemoteDisplay,
-      }
+      },
+      partNumberContext,
     };
 
     // Add chassis to BOM
@@ -1825,6 +2038,8 @@ if (
     setSelectedSlot(null);
     setHasRemoteDisplay(false);
     setSelectedAccessories(new Set());
+    setPnConfig(null);
+    setCodeMap({});
 
     // Show success message
     toast({
@@ -1836,7 +2051,36 @@ if (
   const handleUpdateChassisInBOM = () => {
     if (!selectedChassis || !editingOriginalItem) return;
 
-    const partNumber = buildQTMSPartNumber({
+    const originalAssignments =
+      (editingOriginalItem.slotAssignments && Object.keys(editingOriginalItem.slotAssignments).length > 0
+        ? editingOriginalItem.slotAssignments
+        : convertRackLayoutToAssignments(editingOriginalItem.rackConfiguration)) ||
+      {};
+
+    const normalizedCurrentAssignments = Object.keys(slotAssignments).length > 0 ? slotAssignments : {};
+
+    const assignmentsChanged = haveSlotAssignmentsChanged(
+      originalAssignments as Record<number, Level3Product & Record<string, any>>,
+      normalizedCurrentAssignments as Record<number, Level3Product & Record<string, any>>
+    );
+
+    const originalRemoteDisplay = editingOriginalItem.configuration?.hasRemoteDisplay || false;
+    const remoteDisplayChanged = originalRemoteDisplay !== hasRemoteDisplay;
+
+    const shouldRegeneratePartNumber = assignmentsChanged || remoteDisplayChanged;
+
+    const generatedPartNumber = shouldRegeneratePartNumber
+      ? buildQTMSPartNumber({
+          chassis: selectedChassis,
+          slotAssignments,
+          hasRemoteDisplay,
+          pnConfig,
+          codeMap,
+          includeSuffix: true,
+        })
+      : editingOriginalItem.partNumber || editingOriginalItem.product.partNumber;
+
+    const fallbackPartNumber = buildQTMSPartNumber({
       chassis: selectedChassis,
       slotAssignments,
       hasRemoteDisplay,
@@ -1844,6 +2088,20 @@ if (
       codeMap,
       includeSuffix: true,
     });
+
+    const partNumber = generatedPartNumber || fallbackPartNumber;
+
+    const capturedContext =
+      pnConfig || (codeMap && Object.keys(codeMap).length > 0)
+        ? {
+            pnConfig: pnConfig ? deepClone(pnConfig) : null,
+            codeMap: codeMap ? deepClone(codeMap) : {},
+          }
+        : undefined;
+
+    const partNumberContext = shouldRegeneratePartNumber
+      ? capturedContext
+      : editingOriginalItem.partNumberContext || capturedContext;
 
     const updatedItem: BOMItem = {
       ...editingOriginalItem,
@@ -1858,9 +2116,8 @@ if (
       configuration: {
         hasRemoteDisplay,
       },
+      partNumberContext,
     };
-
-    
 
     const chassisIndex = bomItems.findIndex(item => item.id === editingOriginalItem.id);
 
@@ -1913,6 +2170,8 @@ if (
     setHasRemoteDisplay(false);
     setEditingOriginalItem(null);
     setSelectedAccessories(new Set());
+    setPnConfig(null);
+    setCodeMap({});
 
     toast({
       title: "Configuration Updated",
@@ -1948,7 +2207,25 @@ if (
         {}
       );
       setConfiguringChassis(hydratedChassis);
-      
+
+      const context = resolvePartNumberContext(
+        item.partNumberContext,
+        item.configuration,
+        item.product
+      );
+
+      if (context?.pnConfig) {
+        setPnConfig(deepClone(context.pnConfig));
+      } else {
+        setPnConfig(null);
+      }
+
+      if (context?.codeMap) {
+        setCodeMap(deepClone(context.codeMap));
+      } else {
+        setCodeMap({});
+      }
+
       // Store the original item for restoration if edit is cancelled
       setEditingOriginalItem(item);
       
@@ -1968,6 +2245,35 @@ if (
       }
       
       setHasRemoteDisplay(item.configuration?.hasRemoteDisplay || false);
+      setAutoPlaced(false);
+
+      (async () => {
+        try {
+          const [cfg, codes, l3] = await Promise.all([
+            productDataService.getPartNumberConfig(hydratedChassis.id),
+            productDataService.getPartNumberCodesForLevel2(hydratedChassis.id),
+            productDataService.getLevel3ProductsForLevel2(hydratedChassis.id)
+          ]);
+
+          setLevel3Products(l3);
+
+          if (!context?.pnConfig) {
+            setPnConfig(cfg);
+          }
+
+          if (!context?.codeMap) {
+            setCodeMap(codes);
+          }
+        } catch (error) {
+          console.error('Failed to load PN config/codes for chassis reconfiguration:', error);
+          toast({
+            title: 'Configuration Load Failed',
+            description: 'Unable to load chassis configuration templates. Part number editing may be limited.',
+            variant: 'destructive',
+          });
+        }
+      })();
+
       setTimeout(() => {
         const configSection = document.getElementById('chassis-configuration');
         if (configSection) {
@@ -2220,6 +2526,19 @@ if (
       } else {
         // Insert new BOM items
         for (const item of bomItems) {
+          const serializedAssignments = item.slotAssignments
+            ? serializeSlotAssignments(item.slotAssignments)
+            : undefined;
+          const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(serializedAssignments);
+          const configurationData = {
+            ...(item.configuration || {}),
+            slotAssignments: serializedAssignments,
+            rackConfiguration: rackLayout,
+            level4Config: item.level4Config || null,
+            level4Selections: item.level4Selections || null,
+            partNumberContext: item.partNumberContext ? deepClone(item.partNumberContext) : undefined,
+          };
+
           const { error: bomError } = await supabase.from('bom_items').insert({
             quote_id: quoteId,
             product_id: item.product.id,
@@ -2239,7 +2558,7 @@ if (
                 : 0,
             original_unit_price: item.original_unit_price || item.product.price,
             approved_unit_price: item.approved_unit_price || item.product.price,
-            configuration_data: item.configuration || {},
+            configuration_data: configurationData,
             product_type: 'standard',
           });
 

--- a/src/types/product/interfaces.ts
+++ b/src/types/product/interfaces.ts
@@ -169,6 +169,10 @@ export interface BOMItem {
   margin?: number;
   approved_unit_price?: number;
   price_adjustment_history?: any[];
+  partNumberContext?: {
+    pnConfig: any | null;
+    codeMap: Record<string, any>;
+  };
 }
 
 export type Product = Level1Product | Level2Product | Level3Product;


### PR DESCRIPTION
## Summary
- add helpers to clone stored chassis part-number configuration and detect slot changes when rebuilding layouts
- restore and persist part-number context when loading or saving BOM items so draft reconfigurations reuse the correct templates
- reload chassis configuration assets on edit and only regenerate part numbers when slots or remote display change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddc0ef8b3483269cbbd86e1d088907