### PR TITLE
Fix Level 4 PDF generator syntax regression

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -219,8 +219,6 @@ export const generateQuotePDF = async (
 
       return [];
     }
-
-main
     if (Array.isArray(entries)) {
       return entries
         .map((entry, idx) => {
@@ -526,12 +524,6 @@ main
 
         return [] as Array<{ index: number; value: string }>;
       })();
-
-
-      const selections = payload?.entries
-        ? [...payload.entries].sort((a, b) => a.index - b.index)
-        : [];
-main
       let bodyHtml = '';
 
       if (selections.length > 0) {
@@ -573,11 +565,6 @@ main
       }
 
       if ((!payload || !payload.entries?.length) && selections.length === 0 && entry.rawConfig) {
-
-      if ((!payload || !payload.entries?.length) && selections.length === 0 && entry.rawConfig) {
-
-      if ((!payload || selections.length === 0) && entry.rawConfig) {
-main
         bodyHtml += `<pre class="level4-raw">${escapeHtml(JSON.stringify(entry.rawConfig, null, 2))}</pre>`;
       }
 
@@ -1106,7 +1093,6 @@ main
           <p>Total: $${totalPrice.toLocaleString()}</p>
         </div>
       ` : ''}
-main
 
       ${termsAndConditions ? `
         <div style="page-break-before: always; margin-top: 40px;">


### PR DESCRIPTION
## Summary
- remove merge artefacts from the Level 4 PDF section to restore valid TypeScript
- ensure the fallback raw configuration block only renders once without duplicate declarations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea360032c832696da3a2f4acd1fa2