### PR TITLE
Fix admin quote approval details and discount display

### DIFF
--- a/src/components/admin/quote-approval/QuoteInformation.tsx
+++ b/src/components/admin/quote-approval/QuoteInformation.tsx
@@ -1,54 +1,78 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
 import { Quote } from "@/hooks/useQuotes";
+import { useConfiguredQuoteFields } from "@/hooks/useConfiguredQuoteFields";
 
 interface QuoteInformationProps {
   quote: Partial<Quote>;
 }
 
 export const QuoteInformation = ({ quote }: QuoteInformationProps) => {
+  const { formattedFields, unmappedFields } = useConfiguredQuoteFields(quote?.quote_fields);
+  const priorityBadgeClass = quote?.priority === 'Urgent'
+    ? 'bg-red-500'
+    : quote?.priority === 'High'
+      ? 'bg-orange-500'
+      : quote?.priority === 'Medium'
+        ? 'bg-yellow-500'
+        : 'bg-green-500';
+
   return (
     <Card className="bg-gray-800 border-gray-700">
       <CardHeader>
         <CardTitle className="text-white">Quote Information</CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
-          <div>
-            <Label className="text-gray-400">Customer</Label>
-            <p className="text-white font-medium">{quote?.customer_name || 'N/A'}</p>
-          </div>
-          <div>
-            <Label className="text-gray-400">Oracle ID</Label>
-            <p className="text-white font-medium">{quote?.oracle_customer_id || 'N/A'}</p>
-          </div>
-          <div>
-            <Label className="text-gray-400">SFDC Opportunity</Label>
-            <p className="text-white font-medium">{quote?.sfdc_opportunity || 'N/A'}</p>
-          </div>
-          <div>
-            <Label className="text-gray-400">Payment Terms</Label>
-            <p className="text-white font-medium">{quote?.payment_terms || 'N/A'}</p>
-          </div>
-          <div>
-            <Label className="text-gray-400">Shipping Terms</Label>
-            <p className="text-white font-medium">{quote?.shipping_terms || 'N/A'}</p>
-          </div>
-          <div>
-            <Label className="text-gray-400">Currency</Label>
-            <p className="text-white font-medium">{quote?.currency || 'N/A'}</p>
-          </div>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
+          {quote?.id && (
+            <div>
+              <Label className="text-gray-400">Quote ID</Label>
+              <p className="text-white font-medium font-mono">{quote.id}</p>
+            </div>
+          )}
+          {(quote?.submitted_by_name || quote?.submitted_by_email) && (
+            <div>
+              <Label className="text-gray-400">Requested By</Label>
+              <p className="text-white font-medium">
+                {quote?.submitted_by_name || quote?.submitted_by_email}
+              </p>
+            </div>
+          )}
+          {quote?.priority && (
+            <div>
+              <Label className="text-gray-400">Priority</Label>
+              <div className="mt-1">
+                <Badge className={`${priorityBadgeClass} text-white`}>{quote.priority}</Badge>
+              </div>
+            </div>
+          )}
         </div>
-        
-        {quote?.quote_fields && Object.keys(quote.quote_fields).length > 0 && (
-          <div className="mt-4">
-            <Label className="text-gray-400">Additional Fields</Label>
-            <div className="grid grid-cols-2 gap-2 mt-2">
-              {Object.entries(quote.quote_fields).map(([key, value]) => (
-                <div key={key} className="text-sm">
-                  <span className="text-gray-400">{key}:</span>
-                  <span className="text-white ml-2">{value}</span>
+
+        {formattedFields.length > 0 ? (
+          <div className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2 lg:grid-cols-3">
+            {formattedFields.map((field) => (
+              <div key={field.id} className="space-y-1">
+                <Label className="text-gray-400">{field.label}</Label>
+                <p className="text-white font-medium break-words">{field.formattedValue}</p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-400">
+            No configured quote fields were submitted with this request.
+          </p>
+        )}
+
+        {unmappedFields.length > 0 && (
+          <div className="space-y-3">
+            <Label className="text-gray-400">Additional Quote Information</Label>
+            <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+              {unmappedFields.map(({ key, value }) => (
+                <div key={key}>
+                  <Label className="text-gray-400 capitalize">{key.replace(/_/g, ' ')}</Label>
+                  <p className="text-white">{String(value ?? '—')}</p>
                 </div>
               ))}
             </div>

--- a/src/hooks/useConfiguredQuoteFields.ts
+++ b/src/hooks/useConfiguredQuoteFields.ts
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+
+export interface ConfiguredQuoteField {
+  id: string;
+  label: string;
+  type: string;
+  required: boolean;
+  enabled: boolean;
+  display_order?: number;
+}
+
+export interface FormattedQuoteField extends ConfiguredQuoteField {
+  formattedValue: string;
+}
+
+export interface UnmappedQuoteField {
+  key: string;
+  value: unknown;
+}
+
+const formatQuoteFieldValue = (value: unknown, type: string): string => {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    return "—";
+  }
+
+  if (type === "checkbox") {
+    if (typeof value === "boolean") {
+      return value ? "Yes" : "No";
+    }
+
+    if (typeof value === "string") {
+      return value.toLowerCase() === "true" ? "Yes" : "No";
+    }
+  }
+
+  if (type === "date") {
+    try {
+      const dateValue = value instanceof Date ? value : new Date(value as string);
+      if (Number.isNaN(dateValue.getTime())) {
+        return String(value);
+      }
+      return dateValue.toLocaleDateString();
+    } catch (error) {
+      console.warn("Unable to format date field value", value, error);
+      return String(value);
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      console.warn("Unable to stringify quote field value", value, error);
+      return String(value);
+    }
+  }
+
+  return String(value);
+};
+
+export const useConfiguredQuoteFields = (
+  quoteFields: Record<string, unknown> | undefined
+) => {
+  const [configuredFields, setConfiguredFields] = useState<ConfiguredQuoteField[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchConfiguredFields = async () => {
+      try {
+        const { data, error } = await supabase
+          .from("quote_fields")
+          .select("id,label,type,required,enabled,display_order")
+          .eq("enabled", true)
+          .order("display_order", { ascending: true });
+
+        if (error) {
+          console.error("Failed to fetch quote field configuration for admin view:", error);
+          return;
+        }
+
+        if (isMounted) {
+          setConfiguredFields(data || []);
+        }
+      } catch (fetchError) {
+        console.error("Unexpected error loading quote field configuration:", fetchError);
+      }
+    };
+
+    fetchConfiguredFields();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const formattedFields: FormattedQuoteField[] = useMemo(() => {
+    if (!configuredFields.length) return [];
+
+    const fieldValues = quoteFields || {};
+    return configuredFields.map((field) => ({
+      ...field,
+      formattedValue: formatQuoteFieldValue(fieldValues[field.id], field.type),
+    }));
+  }, [configuredFields, quoteFields]);
+
+  const unmappedFields: UnmappedQuoteField[] = useMemo(() => {
+    if (!quoteFields) return [];
+    const mappedIds = new Set(configuredFields.map((field) => field.id));
+
+    return Object.entries(quoteFields)
+      .filter(([key]) => !mappedIds.has(key))
+      .map(([key, value]) => ({ key, value }));
+  }, [configuredFields, quoteFields]);
+
+  return { configuredFields, formattedFields, unmappedFields };
+};
+

--- a/src/hooks/useQuotes.tsx
+++ b/src/hooks/useQuotes.tsx
@@ -45,6 +45,7 @@ export interface Quote {
 
 export interface BOMItemWithDetails {
   id: string;
+  persisted_id?: string;
   quote_id: string;
   product_id: string;
   name: string;

--- a/src/types/quote.ts
+++ b/src/types/quote.ts
@@ -55,6 +55,12 @@ export interface QuoteItem {
 // Enhanced BOM Item for quote approval with admin editing capabilities
 export interface BOMItemWithDetails extends BOMItem {
   id: string;
+  /**
+   * The identifier persisted in the database for this BOM row. When a BOM
+   * item hasn't been stored yet we still generate a client-side id for React
+   * list rendering, but we skip persistence updates if this value is missing.
+   */
+  persisted_id?: string;
   name: string;
   description?: string;
   part_number?: string;


### PR DESCRIPTION
## Summary
- centralize quote field configuration formatting in a reusable hook and update both the expanded admin card and dialog to render only dynamic quote fields beneath the header metadata
- enhance the project financial analysis to surface discounted totals, requested and approved discounts, and any provided justification alongside the existing revenue metrics
- harden quote approvals by tracking persisted BOM ids locally and using the admin client when available so status updates succeed without duplicate BOM records

## Testing
- npm run lint *(fails: repository already contains numerous `@typescript-eslint/no-explicit-any` violations outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68defdb556888326b47a9457a737a1a8