### PR TITLE
Fix clone quote RPC argument names

### DIFF
--- a/src/components/bom/QuoteViewer.tsx
+++ b/src/components/bom/QuoteViewer.tsx
@@ -304,8 +304,8 @@ const QuoteViewer: React.FC = () => {
     try {
       const { data: newQuoteId, error } = await supabase
         .rpc('clone_quote', {
-          source_quote_id: quote.id,
-          new_user_id: user.id
+          p_source_quote_id: quote.id,
+          p_new_user_id: user.id
         });
 
       if (error) {

--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -469,8 +469,8 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
 
       const { data: newQuoteId, error } = await supabase
         .rpc('clone_quote', {
-          source_quote_id: actualQuoteId,
-          new_user_id: user.id
+          p_source_quote_id: actualQuoteId,
+          p_new_user_id: user.id
         });
 
       if (error) {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1834,7 +1834,7 @@ export type Database = {
         Returns: number
       }
       clone_quote: {
-        Args: { new_user_id: string; source_quote_id: string }
+        Args: { p_new_user_id: string; p_source_quote_id: string }
         Returns: string
       }
       create_user: {


### PR DESCRIPTION
## Summary
- update the quote cloning handlers to call the Supabase RPC with the new parameter names
- refresh the generated Supabase type definition for the clone_quote function so TypeScript matches the backend signature

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e25919b630832698655c765a81798f