### PR TITLE
Align clone quote RPC calls with backend schema

### DIFF
--- a/src/components/bom/QuoteViewer.tsx
+++ b/src/components/bom/QuoteViewer.tsx
@@ -304,8 +304,8 @@ const QuoteViewer: React.FC = () => {
     try {
       const { data: newQuoteId, error } = await supabase
         .rpc('clone_quote', {
-          source_quote_id: quote.id,
-          new_user_id: user.id
+          p_source_quote_id: quote.id,
+          p_new_user_id: user.id
         });
 
       if (error) {
@@ -317,8 +317,8 @@ const QuoteViewer: React.FC = () => {
         description: `Successfully created new draft quote ${newQuoteId}`,
       });
 
-      // Navigate to the new cloned quote in edit mode
-      navigate(`/quote/${newQuoteId}?mode=edit`);
+      // Navigate to the BOM builder for the newly cloned quote
+      navigate(`/bom-edit/${newQuoteId}`);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to clone quote';
       toast({

--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -469,8 +469,8 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
 
       const { data: newQuoteId, error } = await supabase
         .rpc('clone_quote', {
-          source_quote_id: actualQuoteId,
-          new_user_id: user.id
+          p_source_quote_id: actualQuoteId,
+          p_new_user_id: user.id
         });
 
       if (error) {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1834,7 +1834,7 @@ export type Database = {
         Returns: number
       }
       clone_quote: {
-        Args: { new_user_id: string; source_quote_id: string }
+        Args: { p_source_quote_id: string; p_new_user_id: string }
         Returns: string
       }
       create_user: {


### PR DESCRIPTION
## Summary
- pass the `p_source_quote_id` and `p_new_user_id` arguments when invoking the Supabase `clone_quote` RPC so it resolves in the schema cache
- send users to the BOM builder after cloning so the experience matches editing drafts
- update the generated Supabase client types to reflect the RPC parameter names

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e25919b630832698655c765a81798f