### PR TITLE
Prevent Level 4 temporary quotes from inflating draft numbering

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -514,7 +514,9 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
         .from('quotes')
         .select('*', { count: 'exact', head: true })
         .eq('user_id', user.id)
-        .eq('status', 'draft');
+        .eq('status', 'draft')
+        // Exclude temporary Level 4 configuration quotes so they don't affect numbering
+        .not('id', 'like', 'TEMP-%');
 
       if (error) {
         console.error('Error counting drafts:', error);


### PR DESCRIPTION
## Summary
- exclude temporary Level 4 configuration quotes when counting existing drafts for name generation
- add inline comment explaining the TEMP prefix filter for draft sequencing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3da36e7a483269209a219873fd104