### PR TITLE
Align quote cards with account display expectations

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -514,7 +514,9 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
         .from('quotes')
         .select('*', { count: 'exact', head: true })
         .eq('user_id', user.id)
-        .eq('status', 'draft');
+        .eq('status', 'draft')
+        // Exclude temporary Level 4 configuration quotes so they don't affect numbering
+        .not('id', 'like', 'TEMP-%');
 
       if (error) {
         console.error('Error counting drafts:', error);

--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -55,6 +55,54 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
     const currency = quote.currency || 'USD';
     const isDraftQuote = quote.status === 'draft';
 
+    const quoteFields = (quote.quote_fields && typeof quote.quote_fields === 'object')
+      ? quote.quote_fields as Record<string, unknown>
+      : {};
+
+    const getFieldAsString = (...keys: string[]): string | undefined => {
+      for (const key of keys) {
+        const value = quoteFields[key];
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (trimmed.length > 0) {
+            return trimmed;
+          }
+        }
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          return String(value);
+        }
+      }
+      return undefined;
+    };
+
+    const normalizedDraftName = typeof quote.customer_name === 'string' && quote.customer_name.trim().length > 0
+      ? quote.customer_name.trim()
+      : undefined;
+
+    const configuredQuoteName = getFieldAsString('quote_name', 'quoteName', 'name');
+    const configuredCustomerName = getFieldAsString('customer_name', 'customerName', 'customer');
+    const configuredAccount = getFieldAsString(
+      'account',
+      'account_name',
+      'accountName',
+      'customer_account_name',
+      'customerAccountName',
+      'account_number',
+      'accountNumber',
+      'customer_account_number',
+      'customerAccountNumber'
+    );
+
+    const inferredAccountFromCustomer = configuredCustomerName && normalizedDraftName && configuredCustomerName !== normalizedDraftName
+      ? configuredCustomerName
+      : undefined;
+
+    const accountValue = configuredAccount || inferredAccountFromCustomer || null;
+
+    const primaryCustomerLabel = isDraftQuote
+      ? (normalizedDraftName || configuredQuoteName || configuredCustomerName || quote.id)
+      : (configuredCustomerName || normalizedDraftName || configuredQuoteName || quote.id);
+
     const originalValue = isDraftQuote && quote.draft_bom?.items
       ? quote.draft_bom.items.reduce((sum: number, item: any) =>
           sum + ((item.unit_price || item.total_price || item.product?.price || 0) * (item.quantity || 1)), 0)
@@ -92,9 +140,10 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
     return {
       id: quote.id, // Use unique ID for React key
       displayId: quote.id, // Keep original ID for operations
-      displayLabel: isDraftQuote ? 'Draft' : quote.id, // Label to show in UI
-      customer: quote.customer_name || 'Unnamed Customer',
+      displayLabel: primaryCustomerLabel,
+      customer: primaryCustomerLabel,
       oracleCustomerId: quote.oracle_customer_id || 'N/A',
+      account: accountValue,
       currency,
       value: originalValue,
       finalValue,
@@ -182,9 +231,12 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
   };
 
   const filteredQuotes = processedQuotes.filter(quote => {
-    const matchesSearch = quote.customer.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         quote.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         quote.oracleCustomerId.toLowerCase().includes(searchTerm.toLowerCase());
+    const lowerSearch = searchTerm.toLowerCase();
+    const matchesSearch = quote.customer.toLowerCase().includes(lowerSearch) ||
+                         quote.id.toLowerCase().includes(lowerSearch) ||
+                         quote.oracleCustomerId.toLowerCase().includes(lowerSearch) ||
+                         (quote.displayLabel?.toLowerCase().includes(lowerSearch)) ||
+                         (quote.account ? quote.account.toLowerCase().includes(lowerSearch) : false);
     const matchesPriority = priorityFilter === 'All' || 
                            (priorityFilter === 'Draft' && quote.status === 'draft') ||
                            (priorityFilter !== 'Draft' && quote.priority === priorityFilter);
@@ -828,10 +880,9 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
                           {statusBadge.text}
                         </Badge>
                       </div>
-                      {quote.status !== 'draft' && (
-                        <p className="text-gray-400 text-sm mt-1">{quote.customer}</p>
-                      )}
-                      <p className="text-gray-500 text-xs">Oracle: {quote.oracleCustomerId}</p>
+                      <p className="text-gray-400 text-sm mt-1">
+                        Account: {quote.account || '—'}
+                      </p>
                     </div>
                     
                     <div className="text-right">


### PR DESCRIPTION
## Summary
- ensure draft quote cards keep the saved draft name as the primary display label
- expand account extraction to include numeric and alternate field names, inferring account IDs from customer fields when they differ from the draft label
- show only the Account row on quote cards so numeric identifiers appear in the correct place

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3da36e7a483269209a219873fd104