### PR TITLE
Fix duplicate account display in quote list

### DIFF
--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -940,6 +940,7 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
               const priorityBadge = getPriorityBadge(quote.priority);
               const actualQuoteId = quote.displayId || quote.id;
               const isPdfLoading = Boolean(pdfLoadingStates[actualQuoteId]);
+              const formattedAccount = formatAccountDisplay(quote.account);
               return (
                 <div
                   key={quote.id}
@@ -961,13 +962,8 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
                         </p>
                       )}
                       <p className="text-gray-400 text-sm mt-1">
-                        Account: {formatAccountDisplay(quote.account) ?? '—'}
+                        Account: {formattedAccount ?? quote.account ?? '—'}
                       </p>
-                      {quote.account && (
-                        <p className="text-gray-400 text-sm">
-                          Account: {quote.account}
-                        </p>
-                      )}
                     </div>
                     
                     <div className="text-right">


### PR DESCRIPTION
## Summary
- render the account field only once on quote cards
- prefer the formatted account display when available and fall back to the raw value

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e470a0ce048326be402206acdaca2a