### PR TITLE
Ensure draft account changes appear in quote list

### DIFF
--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -94,7 +94,11 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
       return {} as Record<string, unknown>;
     })();
 
-    const combinedFields = { ...draftQuoteFields, ...quoteFields };
+    // When a user resumes editing a draft quote, the latest field values live in
+    // the draft payload. Ensure those values take precedence over the persisted
+    // quote fields by spreading the stored fields first and the draft fields
+    // last.
+    const combinedFields = { ...quoteFields, ...draftQuoteFields };
 
     const getFieldAsString = (...keys: string[]): string | undefined => {
       for (const key of keys) {
@@ -940,6 +944,7 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
               const priorityBadge = getPriorityBadge(quote.priority);
               const actualQuoteId = quote.displayId || quote.id;
               const isPdfLoading = Boolean(pdfLoadingStates[actualQuoteId]);
+              const formattedAccount = formatAccountDisplay(quote.account);
               return (
                 <div
                   key={quote.id}
@@ -961,13 +966,8 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
                         </p>
                       )}
                       <p className="text-gray-400 text-sm mt-1">
-                        Account: {formatAccountDisplay(quote.account) ?? '—'}
+                        Account: {formattedAccount ?? quote.account ?? '—'}
                       </p>
-                      {quote.account && (
-                        <p className="text-gray-400 text-sm">
-                          Account: {quote.account}
-                        </p>
-                      )}
                     </div>
                     
                     <div className="text-right">


### PR DESCRIPTION
## Summary
- allow draft quote field values to override persisted fields when preparing quote metadata
- ensure the quote account header updates after editing a draft

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e470a0ce048326be402206acdaca2a