### PR TITLE
Fix account display for cloned quote drafts

### DIFF
--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -44,7 +44,7 @@ const formatAccountDisplay = (rawValue?: string | null): string | null => {
     return null;
   }
 
-  return segments[0];
+  return segments[segments.length - 1];
 };
 
 const parseJsonValue = (value: unknown): unknown => {
@@ -330,7 +330,10 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
       const seen = new Set<string>();
 
       for (const candidate of accountCandidates) {
-        for (const segment of extractAccountSegments(candidate)) {
+        const segments = extractAccountSegments(candidate);
+
+        for (let index = segments.length - 1; index >= 0; index -= 1) {
+          const segment = segments[index];
           const normalizedKey = segment.toLowerCase();
           if (seen.has(normalizedKey)) {
             continue;


### PR DESCRIPTION
## Summary
- ensure account formatting pulls the most recent account segment when multiple values are present
- update account extraction to prefer the latest segment so cloned drafts show the updated account name

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e4dd5ece5c8326a3e35985214b7d8a