### PR TITLE
Prioritize draft BOM account data in quote list

### DIFF
--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -422,10 +422,10 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
 
     const accountCandidates = [
       draftAccountFieldValue,
+      draftBomAccountFieldValue,
       combinedAccountFieldValue,
       configuredAccount,
       persistedAccountFieldValue,
-      draftBomAccountFieldValue,
       ...topLevelAccountCandidates,
       configuredCustomerName,
       normalizedDraftName,


### PR DESCRIPTION
## Summary
- prioritize account values extracted from draft BOM data before falling back to persisted quote fields so cloned drafts display their updated account information

## Testing
- npm run lint *(fails: existing lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e520735844832689bf3a487d30b438