### PR TITLE
Stabilize account field selection for quote list

### DIFF
--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -235,7 +235,16 @@ const findAccountFieldValue = (
     const prioritizedValue = segments[segments.length - 1];
     const priority = getAccountPriorityForKey(keyHint);
 
-    if (!bestCandidate || priority < bestCandidate.priority || (priority === bestCandidate.priority && prioritizedValue !== bestCandidate.value)) {
+    if (!bestCandidate || priority < bestCandidate.priority) {
+      bestCandidate = { value: prioritizedValue, priority };
+      return;
+    }
+
+    if (
+      bestCandidate &&
+      priority === bestCandidate.priority &&
+      prioritizedValue.localeCompare(bestCandidate.value, undefined, { sensitivity: 'base' }) === 0
+    ) {
       bestCandidate = { value: prioritizedValue, priority };
     }
   };
@@ -422,10 +431,10 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
 
     const accountCandidates = [
       draftAccountFieldValue,
+      draftBomAccountFieldValue,
       combinedAccountFieldValue,
       configuredAccount,
       persistedAccountFieldValue,
-      draftBomAccountFieldValue,
       ...topLevelAccountCandidates,
       configuredCustomerName,
       normalizedDraftName,


### PR DESCRIPTION
## Summary
- keep the highest-priority account candidate that is discovered first so draft updates continue to surface in the quote list

## Testing
- npm run lint *(fails: numerous pre-existing lint violations across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e520735844832689bf3a487d30b438