### PR TITLE
Unify customer name syncing and refresh submitted BOM items

### DIFF
--- a/src/components/bom/BOMBuilder.tsx
+++ b/src/components/bom/BOMBuilder.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
@@ -29,6 +29,7 @@ import QTMSConfigurationEditor from './QTMSConfigurationEditor';
 import { consolidateQTMSConfiguration, createQTMSBOMItem, ConsolidatedQTMS, QTMSConfiguration } from '@/utils/qtmsConsolidation';
 import { buildQTMSPartNumber } from '@/utils/qtmsPartNumberBuilder';
 import { findOptimalBushingPlacement, findExistingBushingSlots, isBushingCard } from '@/utils/bushingValidation';
+import { deriveCustomerNameFromFields } from '@/utils/customerName';
 import { useAuth } from '@/hooks/useAuth';
 import { useQuoteValidation } from './QuoteFieldValidation';
 import { usePermissions, FEATURES } from '@/hooks/usePermissions';
@@ -201,6 +202,77 @@ const deepClone = <T,>(value: T): T => {
   }
 };
 
+const normalizeDraftBomValue = (value: unknown): Record<string, any> | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, any>;
+      }
+    } catch (error) {
+      console.warn('Failed to parse draft BOM string. Skipping draft BOM merge.', error);
+      return null;
+    }
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, any>;
+  }
+
+  return null;
+};
+
+const getDerivedCustomerName = (
+  fields: Record<string, any> | null | undefined,
+  fallback?: string | null,
+): string | null => {
+  const derived = deriveCustomerNameFromFields(fields ?? undefined, fallback ?? null);
+  if (typeof derived === 'string') {
+    const trimmed = derived.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return null;
+};
+
+const resolveCustomerNameFromFields = (
+  fields: Record<string, any> | null | undefined,
+  fallback?: string | null,
+): string => {
+  const derived = getDerivedCustomerName(fields, fallback);
+  if (derived) {
+    return derived;
+  }
+
+  if (typeof fallback === 'string' && fallback.trim().length > 0) {
+    return fallback.trim();
+  }
+
+  return 'Pending Customer';
+};
+
+const mergeQuoteFieldsIntoDraftBom = (
+  draftBom: unknown,
+  fields: Record<string, any>,
+): Record<string, any> | null => {
+  const base = normalizeDraftBomValue(draftBom);
+  if (!base) {
+    return null;
+  }
+
+  return {
+    ...base,
+    quoteFields: fields,
+    quote_fields: fields,
+  };
+};
+
 const resolvePartNumberContext = (...candidates: Array<any>) => {
   for (const candidate of candidates) {
     if (!candidate) continue;
@@ -310,6 +382,9 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
   const [currentQuoteId, setCurrentQuoteId] = useState<string | null>(quoteId || null);
   const [currentQuote, setCurrentQuote] = useState<any>(null);
   const [isDraftMode, setIsDraftMode] = useState(mode === 'edit' || mode === 'new');
+
+  const pendingQuoteFieldSyncRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSyncedQuoteFieldsRef = useRef<string>(JSON.stringify({}));
 
   // Admin-driven part number config and codes for the selected chassis
   const [pnConfig, setPnConfig] = useState<any | null>(null);
@@ -517,11 +592,10 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
       console.log('Creating draft quote for user:', user.id);
       
       // Generate identifiers for the draft quote
-      const providedCustomerName = getQuoteFieldValue('customer_name');
-      const resolvedCustomerName =
-        typeof providedCustomerName === 'string' && providedCustomerName.trim().length > 0
-          ? providedCustomerName.trim()
-          : 'Pending Customer';
+      const resolvedCustomerName = resolveCustomerNameFromFields(
+        quoteFields,
+        getStringFieldValue('customer_name', 'Pending Customer'),
+      );
 
       const draftQuoteId = await generateUniqueDraftName(user.id, user.email);
 
@@ -590,8 +664,9 @@ const BOMBuilder = ({ onBOMUpdate, canSeePrices, canSeeCosts = false, quoteId, m
         title: 'Quote Created',
         description: `Draft ${draftQuoteId} for ${resolvedCustomerName} is ready for configuration. Your progress will be automatically saved.`
       });
-      
+
       console.log('Draft quote created successfully:', draftQuoteId);
+      lastSyncedQuoteFieldsRef.current = JSON.stringify(quoteFields ?? {});
     } catch (error) {
       console.error('Error creating draft quote:', error);
       toast({
@@ -952,6 +1027,10 @@ if (
       // Restore quote fields
       if (quote.quote_fields) {
         setQuoteFields(quote.quote_fields);
+        lastSyncedQuoteFieldsRef.current = JSON.stringify(quote.quote_fields ?? {});
+      } else {
+        setQuoteFields({});
+        lastSyncedQuoteFieldsRef.current = JSON.stringify({});
       }
       
       // Restore discount settings
@@ -1000,6 +1079,134 @@ if (
     }
   };
 
+  const buildDraftBomSnapshot = () => {
+    const rackLayoutSummaries: Array<Record<string, any>> = [];
+    const level4Summaries: Array<Record<string, any>> = [];
+
+    let totalValue = 0;
+    let totalCost = 0;
+
+    const items = bomItems.map(item => {
+      const price = item.product.price || 0;
+      const cost = item.product.cost || 0;
+
+      totalValue += price * item.quantity;
+      totalCost += cost * item.quantity;
+
+      if (price === 0) {
+        console.warn(`Item ${item.product.name} has 0 price - this may cause issues`);
+      }
+
+      const serializedSlots = item.slotAssignments
+        ? serializeSlotAssignments(item.slotAssignments)
+        : undefined;
+
+      const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(serializedSlots);
+
+      const partNumberContext =
+        item.partNumberContext ||
+        resolvePartNumberContext(item.configuration, item.product);
+
+      if (rackLayout?.slots && rackLayout.slots.length > 0) {
+        rackLayoutSummaries.push({
+          productId: item.product.id,
+          productName: item.product.name,
+          partNumber: item.partNumber || item.product.partNumber,
+          layout: rackLayout,
+        });
+      }
+
+      const slotLevel4 = serializedSlots?.filter(slot => slot.level4Config || slot.level4Selections) || [];
+
+      if (slotLevel4.length > 0) {
+        level4Summaries.push({
+          productId: item.product.id,
+          productName: item.product.name,
+          partNumber: item.partNumber || item.product.partNumber,
+          slots: slotLevel4.map(slot => ({
+            slot: slot.slot,
+            cardName: slot.displayName || slot.name,
+            configuration: slot.level4Config || slot.level4Selections,
+          })),
+        });
+      }
+
+      if (item.level4Config) {
+        level4Summaries.push({
+          productId: item.product.id,
+          productName: item.product.name,
+          partNumber: item.partNumber || item.product.partNumber,
+          configuration: item.level4Config,
+        });
+      }
+
+      return {
+        product_id: item.product.id,
+        name: item.product.name,
+        description: item.product.description,
+        part_number: item.partNumber || item.product.partNumber,
+        quantity: item.quantity,
+        unit_price: price,
+        unit_cost: cost,
+        total_price: price * item.quantity,
+        total_cost: cost * item.quantity,
+        margin: cost > 0 ? ((price - cost) / price) * 100 : 100,
+        configuration_data: {
+          ...item.product,
+          price,
+          cost,
+          partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
+        },
+        product_type: 'standard',
+        slotAssignments: serializedSlots,
+        rackConfiguration: rackLayout,
+        level4Config: item.level4Config || null,
+        level4Selections: item.level4Selections || null,
+        partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
+      };
+    });
+
+    const grossProfit = totalValue - totalCost;
+    const quoteOriginalMargin = totalValue > 0 ? (grossProfit / totalValue) * 100 : 0;
+    const draftOriginalMargin =
+      totalCost > 0 && totalValue > 0 ? (grossProfit / totalValue) * 100 : 100;
+    const discountedValue = totalValue * (1 - discountPercentage / 100);
+    const discountedMargin =
+      totalCost > 0 && discountedValue > 0
+        ? ((discountedValue - totalCost) / discountedValue) * 100
+        : 100;
+
+    const draftBomData = {
+      items,
+      quoteFields,
+      discountPercentage,
+      discountJustification,
+      totals: {
+        totalValue,
+        totalCost,
+        grossProfit,
+        originalMargin: draftOriginalMargin,
+        discountedValue,
+        discountedMargin,
+      },
+      rackLayouts: rackLayoutSummaries,
+      level4Configurations: level4Summaries,
+    };
+
+    return {
+      draftBomData,
+      totals: {
+        totalValue,
+        totalCost,
+        grossProfit,
+        originalMargin: quoteOriginalMargin,
+        draftOriginalMargin,
+        discountedValue,
+        discountedMargin,
+      },
+    };
+  };
+
   // Manual save as draft function with better error handling and feedback
   const handleSaveAsDraft = async () => {
     if (!user?.id) {
@@ -1023,23 +1230,10 @@ if (
     try {
       console.log('Starting draft save process...');
 
-      // Extract account value from quoteFields (prioritize fields with "account" in the key)
-      const accountFromFields = (() => {
-        for (const [key, value] of Object.entries(quoteFields)) {
-          const lowerKey = key.toLowerCase();
-          if (lowerKey.includes('account') && typeof value === 'string' && value.trim()) {
-            return value.trim();
-          }
-        }
-        // Fall back to customer_name field
-        const customerNameValue = getQuoteFieldValue('customer_name');
-        if (typeof customerNameValue === 'string' && customerNameValue.trim().length > 0) {
-          return customerNameValue.trim();
-        }
-        return null;
-      })();
-      
-      const resolvedCustomerName = accountFromFields || 'Pending Customer';
+      const resolvedCustomerName = resolveCustomerNameFromFields(
+        quoteFields,
+        currentQuote?.customer_name ?? 'Pending Customer',
+      );
 
       const defaultOracleCustomerId =
         typeof currentQuote?.oracle_customer_id === 'string' && currentQuote.oracle_customer_id.trim().length > 0
@@ -1055,6 +1249,9 @@ if (
 
       let quoteId = currentQuoteId;
       
+      const { draftBomData, totals } = buildDraftBomSnapshot();
+      const { totalValue, totalCost, grossProfit, originalMargin } = totals;
+
       // Create new draft if none exists
       if (!quoteId) {
         console.log('No current quote ID, creating new draft quote');
@@ -1062,12 +1259,6 @@ if (
         const newQuoteId = await generateUniqueDraftName(user.id, user.email);
 
         console.log('Generated new draft quote ID:', newQuoteId);
-
-        // Calculate totals from BOM items
-        const totalValue = bomItems.reduce((sum, item) => sum + (item.product.price * item.quantity), 0);
-        const totalCost = bomItems.reduce((sum, item) => sum + ((item.product.cost || 0) * item.quantity), 0);
-        const grossProfit = totalValue - totalCost;
-        const originalMargin = totalValue > 0 ? ((totalValue - totalCost) / totalValue) * 100 : 0;
 
         const resolvedPriority = getStringFieldValue('priority', 'Medium');
         const resolvedShippingTerms = getStringFieldValue('shipping_terms', 'Ex-Works', 'Ex-Works');
@@ -1092,10 +1283,7 @@ if (
           is_rep_involved: resolvedRepInvolved,
           status: 'draft' as const,
           quote_fields: quoteFields,
-          draft_bom: {
-            items: bomItems,
-            lastSaved: new Date().toISOString()
-          },
+          draft_bom: draftBomData,
           original_quote_value: totalValue,
           discounted_value: totalValue,
           total_cost: totalCost,
@@ -1122,20 +1310,18 @@ if (
           customer_name: resolvedCustomerName,
           oracle_customer_id: resolvedOracleCustomerId,
           sfdc_opportunity: resolvedSfdcOpportunity,
-          status: 'draft'
+          status: 'draft',
+          quote_fields: quoteFields,
+          draft_bom: draftBomData,
         });
         quoteId = newQuoteId;
 
         window.history.replaceState({}, '', `/#configure?quoteId=${encodeURIComponent(newQuoteId)}`);
 
         console.log('Draft quote created successfully:', quoteId);
+        lastSyncedQuoteFieldsRef.current = JSON.stringify(quoteFields ?? {});
       } else {
         // Update existing draft - also calculate and update totals
-        const totalValue = bomItems.reduce((sum, item) => sum + (item.product.price * item.quantity), 0);
-        const totalCost = bomItems.reduce((sum, item) => sum + ((item.product.cost || 0) * item.quantity), 0);
-        const grossProfit = totalValue - totalCost;
-        const originalMargin = totalValue > 0 ? ((totalValue - totalCost) / totalValue) * 100 : 0;
-
         const { error: updateError } = await supabase
           .from('quotes')
           .update({
@@ -1143,10 +1329,7 @@ if (
             oracle_customer_id: resolvedOracleCustomerId,
             sfdc_opportunity: resolvedSfdcOpportunity,
             quote_fields: quoteFields,
-            draft_bom: {
-              items: bomItems,
-              lastSaved: new Date().toISOString()
-            },
+            draft_bom: draftBomData,
             original_quote_value: totalValue,
             discounted_value: totalValue,
             total_cost: totalCost,
@@ -1168,8 +1351,11 @@ if (
           customer_name: resolvedCustomerName,
           oracle_customer_id: resolvedOracleCustomerId,
           sfdc_opportunity: resolvedSfdcOpportunity,
+          quote_fields: quoteFields,
+          draft_bom: draftBomData,
         } : prev);
         console.log('Draft quote updated successfully:', quoteId);
+        lastSyncedQuoteFieldsRef.current = JSON.stringify(quoteFields ?? {});
       }
 
       toast({
@@ -1192,134 +1378,29 @@ if (
     if (!currentQuoteId || !user?.id) return;
     
     try {
-      // Calculate totals
-      const totalValue = bomItems.reduce((sum, item) => 
-        sum + (item.product.price * item.quantity), 0
-      );
-      
-      const totalCost = bomItems.reduce((sum, item) => 
-        sum + ((item.product.cost || 0) * item.quantity), 0
-      );
-      
-      // Validate and prepare draft BOM data
-      const rackLayoutSummaries: Array<Record<string, any>> = [];
-      const level4Summaries: Array<Record<string, any>> = [];
-
-      const draftBomData = {
-        items: bomItems.map(item => {
-          const price = item.product.price || 0;
-          const cost = item.product.cost || 0;
-
-          // Log warning if prices are missing
-          if (price === 0) {
-            console.warn(`Item ${item.product.name} has 0 price - this may cause issues`);
-          }
-
-          const serializedSlots = item.slotAssignments ? serializeSlotAssignments(item.slotAssignments) : undefined;
-        const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(serializedSlots);
-
-        const partNumberContext =
-          item.partNumberContext ||
-          resolvePartNumberContext(item.configuration, item.product);
-
-        if (rackLayout?.slots && rackLayout.slots.length > 0) {
-          rackLayoutSummaries.push({
-            productId: item.product.id,
-            productName: item.product.name,
-              partNumber: item.partNumber || item.product.partNumber,
-              layout: rackLayout,
-            });
-          }
-
-          const slotLevel4 = serializedSlots?.filter(slot => slot.level4Config || slot.level4Selections) || [];
-          if (slotLevel4.length > 0) {
-            level4Summaries.push({
-              productId: item.product.id,
-              productName: item.product.name,
-              partNumber: item.partNumber || item.product.partNumber,
-              slots: slotLevel4.map(slot => ({
-                slot: slot.slot,
-                cardName: slot.displayName || slot.name,
-                configuration: slot.level4Config || slot.level4Selections,
-              })),
-            });
-          }
-
-          if (item.level4Config) {
-            level4Summaries.push({
-              productId: item.product.id,
-              productName: item.product.name,
-              partNumber: item.partNumber || item.product.partNumber,
-              configuration: item.level4Config,
-            });
-          }
-
-          return {
-            product_id: item.product.id,
-            name: item.product.name,
-            description: item.product.description,
-            part_number: item.partNumber || item.product.partNumber,
-            quantity: item.quantity,
-            unit_price: price,
-            unit_cost: cost,
-            total_price: price * item.quantity,
-            total_cost: cost * item.quantity,
-            margin: cost > 0
-              ? ((price - cost) / price) * 100
-              : 100,
-            configuration_data: {
-              ...item.product,
-              price,
-              cost,
-              partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
-            },
-            product_type: 'standard',
-            slotAssignments: serializedSlots,
-            rackConfiguration: rackLayout,
-            level4Config: item.level4Config || null,
-            level4Selections: item.level4Selections || null,
-            partNumberContext: partNumberContext ? deepClone(partNumberContext) : undefined,
-          };
-        }),
-        quoteFields,
-        discountPercentage,
-        discountJustification,
-        totals: {
-          totalValue,
-          totalCost,
-          grossProfit: totalValue - totalCost,
-          originalMargin: totalCost > 0 ? ((totalValue - totalCost) / totalValue) * 100 : 100,
-          discountedValue: totalValue * (1 - discountPercentage / 100),
-          discountedMargin: totalCost > 0 ? (((totalValue * (1 - discountPercentage / 100)) - totalCost) / (totalValue * (1 - discountPercentage / 100))) * 100 : 100
-        },
-        rackLayouts: rackLayoutSummaries,
-        level4Configurations: level4Summaries,
-      };
+      const { draftBomData, totals } = buildDraftBomSnapshot();
+      const {
+        totalValue,
+        totalCost,
+        discountedValue,
+        discountedMargin,
+        grossProfit,
+        draftOriginalMargin,
+      } = totals;
 
       // Update quote with draft BOM data
-      const providedCustomerName = getQuoteFieldValue('customer_name');
-      const draftCustomerName =
-        typeof providedCustomerName === 'string' && providedCustomerName.trim().length > 0
-          ? providedCustomerName.trim()
-          : (currentQuote?.customer_name?.trim() || 'Pending Customer');
+      const updatedCustomerName = resolveCustomerNameFromFields(
+        quoteFields,
+        currentQuote?.customer_name ?? 'Pending Customer',
+      );
 
       const timestampFallback = `DRAFT-${Date.now()}`;
       const resolvedOracleCustomerId = getStringFieldValue('oracle_customer_id', 'DRAFT', 'DRAFT');
       const resolvedSfdcOpportunity = getStringFieldValue('sfdc_opportunity', timestampFallback, timestampFallback);
       
-      // Extract account value from quoteFields for customer_name update
-      const accountFromFields = (() => {
-        for (const [key, value] of Object.entries(quoteFields)) {
-          const lowerKey = key.toLowerCase();
-          if (lowerKey.includes('account') && typeof value === 'string' && value.trim()) {
-            return value.trim();
-          }
-        }
-        return null;
-      })();
-      
-      const updatedCustomerName = accountFromFields || draftCustomerName;
-      
+      // Use the same normalization logic as the auto-sync path so any account
+      // style field (including select objects) can drive the persisted
+      // customer name.
       const { error: quoteError } = await supabase
         .from('quotes')
         .update({
@@ -1327,12 +1408,12 @@ if (
           oracle_customer_id: resolvedOracleCustomerId,
           sfdc_opportunity: resolvedSfdcOpportunity,
           original_quote_value: totalValue,
-          discounted_value: totalValue * (1 - discountPercentage / 100),
+          discounted_value: discountedValue,
           requested_discount: discountPercentage,
           total_cost: totalCost,
-          gross_profit: totalValue - totalCost,
-          original_margin: totalCost > 0 ? ((totalValue - totalCost) / totalValue) * 100 : 100,
-          discounted_margin: totalCost > 0 ? (((totalValue * (1 - discountPercentage / 100)) - totalCost) / (totalValue * (1 - discountPercentage / 100))) * 100 : 100,
+          gross_profit: grossProfit,
+          original_margin: draftOriginalMargin,
+          discounted_margin: discountedMargin,
           quote_fields: quoteFields,
           discount_justification: discountJustification,
           draft_bom: draftBomData,
@@ -1340,9 +1421,29 @@ if (
           updated_at: new Date().toISOString()
         })
         .eq('id', currentQuoteId);
-        
+
       if (quoteError) throw quoteError;
-      
+
+      lastSyncedQuoteFieldsRef.current = JSON.stringify(quoteFields ?? {});
+
+      setCurrentQuote(prev => {
+        if (!prev) {
+          return prev;
+        }
+
+        const nextQuote: Record<string, any> = {
+          ...prev,
+          quote_fields: quoteFields,
+          draft_bom: draftBomData,
+        };
+
+        if (updatedCustomerName) {
+          nextQuote.customer_name = updatedCustomerName;
+        }
+
+        return nextQuote;
+      });
+
       if (!autoSave) {
         toast({
           title: 'Draft Saved',
@@ -1379,6 +1480,95 @@ if (
   const handleQuoteFieldChange = (fieldId: string, value: any) => {
     setQuoteFields(prev => ({ ...prev, [fieldId]: value }));
   };
+
+  const syncQuoteFieldsToSupabase = useCallback(
+    async (fields: Record<string, any>, serializedSnapshot: string) => {
+      if (!currentQuoteId || !isDraftMode) {
+        return;
+      }
+
+      try {
+        const derivedCustomerName = getDerivedCustomerName(fields, currentQuote?.customer_name ?? null);
+        const draftBomUpdate = mergeQuoteFieldsIntoDraftBom(currentQuote?.draft_bom, fields);
+        const updatePayload: Record<string, any> = {
+          quote_fields: fields,
+          updated_at: new Date().toISOString(),
+        };
+
+        if (derivedCustomerName) {
+          updatePayload.customer_name = derivedCustomerName;
+        }
+
+        if (draftBomUpdate) {
+          updatePayload.draft_bom = draftBomUpdate;
+        }
+
+        const { error } = await supabase
+          .from('quotes')
+          .update(updatePayload)
+          .eq('id', currentQuoteId);
+
+        if (error) {
+          console.error('Error syncing quote fields to Supabase:', error);
+          return;
+        }
+
+        lastSyncedQuoteFieldsRef.current = serializedSnapshot;
+
+        setCurrentQuote(prev => {
+          if (!prev) {
+            return prev;
+          }
+
+          const nextDraftBom = mergeQuoteFieldsIntoDraftBom(prev.draft_bom, fields);
+          const nextQuote: Record<string, any> = {
+            ...prev,
+            quote_fields: fields,
+          };
+
+          if (derivedCustomerName) {
+            nextQuote.customer_name = derivedCustomerName;
+          }
+
+          if (nextDraftBom) {
+            nextQuote.draft_bom = nextDraftBom;
+          }
+
+          return nextQuote;
+        });
+      } catch (error) {
+        console.error('Failed to sync quote fields to Supabase:', error);
+      }
+    },
+    [currentQuoteId, isDraftMode, currentQuote?.customer_name, currentQuote?.draft_bom]
+  );
+
+  useEffect(() => {
+    if (!currentQuoteId || !isDraftMode) {
+      return;
+    }
+
+    const serialized = JSON.stringify(quoteFields ?? {});
+    if (serialized === lastSyncedQuoteFieldsRef.current) {
+      return;
+    }
+
+    if (pendingQuoteFieldSyncRef.current) {
+      clearTimeout(pendingQuoteFieldSyncRef.current);
+    }
+
+    pendingQuoteFieldSyncRef.current = setTimeout(() => {
+      pendingQuoteFieldSyncRef.current = null;
+      syncQuoteFieldsToSupabase(quoteFields ?? {}, serialized);
+    }, 750);
+
+    return () => {
+      if (pendingQuoteFieldSyncRef.current) {
+        clearTimeout(pendingQuoteFieldSyncRef.current);
+        pendingQuoteFieldSyncRef.current = null;
+      }
+    };
+  }, [quoteFields, currentQuoteId, isDraftMode, syncQuoteFieldsToSupabase]);
 
   // Load Level 1 products for dynamic tabs - use real Supabase data
   const [level1Products, setLevel1Products] = useState<Level1Product[]>([]);
@@ -2571,6 +2761,7 @@ if (
     console.log('Quote submitted with ID:', quoteId);
     setBomItems([]);
     setQuoteFields({});
+    lastSyncedQuoteFieldsRef.current = JSON.stringify({});
     setDiscountPercentage(0);
     setDiscountJustification('');
     onBOMUpdate([]);
@@ -2649,7 +2840,10 @@ if (
         setIsDraftMode(false);
       }
 
-      const customerNameValue = getStringFieldValue('customer_name', 'Unnamed Customer');
+      const customerNameValue = resolveCustomerNameFromFields(
+        quoteFields,
+        getStringFieldValue('customer_name', 'Unnamed Customer'),
+      );
       const oracleCustomerIdValue = getStringFieldValue('oracle_customer_id', 'TBD', 'N/A');
       const sfdcOpportunityValue = getStringFieldValue('sfdc_opportunity', 'TBD', 'N/A');
       const priorityValue = getStringFieldValue('priority', 'Medium');
@@ -2754,54 +2948,72 @@ if (
         return;
       }
 
-      if (!isSubmittingExistingDraft) {
-        // Insert new BOM items
-        for (const item of bomItems) {
-          const serializedAssignments = item.slotAssignments
-            ? serializeSlotAssignments(item.slotAssignments)
-            : undefined;
-          const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(serializedAssignments);
-          const configurationData = {
-            ...(item.configuration || {}),
-            slotAssignments: serializedAssignments,
-            rackConfiguration: rackLayout,
-            level4Config: item.level4Config || null,
-            level4Selections: item.level4Selections || null,
-            partNumberContext: item.partNumberContext ? deepClone(item.partNumberContext) : undefined,
-          };
+      const bomInsertPayload = bomItems.map(item => {
+        const serializedAssignments = item.slotAssignments
+          ? serializeSlotAssignments(item.slotAssignments)
+          : undefined;
+        const rackLayout = item.rackConfiguration || buildRackLayoutFromAssignments(serializedAssignments);
 
-          const { error: bomError } = await supabase.from('bom_items').insert({
-            quote_id: quoteId,
-            product_id: item.product.id,
-            name: item.product.name,
-            description: item.product.description || '',
-            part_number: item.product.partNumber || item.partNumber || '',
-            quantity: item.quantity,
-            unit_price: item.product.price,
-            unit_cost: item.product.cost || 0,
-            total_price: item.product.price * item.quantity,
-            total_cost: (item.product.cost || 0) * item.quantity,
-            margin:
-              item.product.price > 0
-                ? ((item.product.price - (item.product.cost || 0)) /
-                    item.product.price) *
-                  100
-                : 0,
-            original_unit_price: item.original_unit_price || item.product.price,
-            approved_unit_price: item.approved_unit_price || item.product.price,
-            configuration_data: configurationData,
-            product_type: 'standard',
+        const configurationData = {
+          ...(item.configuration || {}),
+          slotAssignments: serializedAssignments,
+          rackConfiguration: rackLayout,
+          level4Config: item.level4Config || null,
+          level4Selections: item.level4Selections || null,
+        } as Record<string, any>;
+
+        if (item.partNumberContext) {
+          configurationData.partNumberContext = deepClone(item.partNumberContext);
+        }
+
+        return {
+          quote_id: quoteId,
+          product_id: item.product.id,
+          name: item.product.name,
+          description: item.product.description || '',
+          part_number: item.product.partNumber || item.partNumber || '',
+          quantity: item.quantity,
+          unit_price: item.product.price,
+          unit_cost: item.product.cost || 0,
+          total_price: item.product.price * item.quantity,
+          total_cost: (item.product.cost || 0) * item.quantity,
+          margin:
+            item.product.price > 0
+              ? ((item.product.price - (item.product.cost || 0)) / item.product.price) * 100
+              : 0,
+          original_unit_price: item.original_unit_price || item.product.price,
+          approved_unit_price: item.approved_unit_price || item.product.price,
+          configuration_data: configurationData,
+          product_type: 'standard',
+        };
+      });
+
+      if (bomInsertPayload.length > 0) {
+        const { error: deleteError } = await supabase
+          .from('bom_items')
+          .delete()
+          .eq('quote_id', quoteId);
+
+        if (deleteError) {
+          console.error('Failed to clear existing BOM items:', deleteError);
+          toast({
+            title: 'BOM Item Error',
+            description: deleteError.message || 'Failed to prepare BOM items for submission',
+            variant: 'destructive',
           });
+          throw deleteError;
+        }
 
-          if (bomError) {
-            console.error('SUPABASE BOM ERROR:', bomError);
-            toast({
-              title: 'BOM Item Error',
-              description: bomError.message || 'Failed to create BOM item',
-              variant: 'destructive',
-            });
-            throw bomError;
-          }
+        const { error: bomError } = await supabase.from('bom_items').insert(bomInsertPayload);
+
+        if (bomError) {
+          console.error('SUPABASE BOM ERROR:', bomError);
+          toast({
+            title: 'BOM Item Error',
+            description: bomError.message || 'Failed to create BOM item',
+            variant: 'destructive',
+          });
+          throw bomError;
         }
       }
 

--- a/src/components/quotes/QuoteManager.tsx
+++ b/src/components/quotes/QuoteManager.tsx
@@ -14,6 +14,11 @@ import { supabase } from "@/integrations/supabase/client";
 import { cloneQuoteWithFallback } from "@/utils/cloneQuote";
 import { normalizeQuoteId } from "@/utils/quoteIdGenerator";
 import {
+  coerceFieldValueToString,
+  extractAccountSegments,
+  findAccountFieldValue,
+} from '@/utils/customerName';
+import {
   deserializeSlotAssignments,
   buildRackLayoutFromAssignments,
   type SerializedSlotAssignment,
@@ -25,67 +30,6 @@ interface QuoteManagerProps {
 
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0;
-
-const extractAccountSegments = (rawValue?: string | null): string[] => {
-  if (!rawValue) {
-    return [];
-  }
-
-  return String(rawValue)
-    .split(/\r?\n+/)
-    .flatMap((segment) => segment.split(/[;,]+/))
-    .map((segment) => segment.replace(/^account\s*:?\s*/i, "").trim())
-    .filter(Boolean);
-};
-
-const normalizeKeyToTokens = (key: string): string[] =>
-  key
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/[_\-.]+/g, " ")
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(Boolean);
-
-const DATE_TIME_INDICATOR_TOKENS = new Set([
-  "date",
-  "time",
-  "expiration",
-  "expires",
-  "effective",
-  "start",
-  "end",
-  "timestamp",
-]);
-
-const ISO_DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})(?:[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
-
-const isLikelyAccountKey = (key: string | undefined): key is string => {
-  if (!key) {
-    return false;
-  }
-
-  const tokens = normalizeKeyToTokens(key);
-  if (tokens.length === 0) {
-    return false;
-  }
-
-  const hasAccountToken = tokens.some((token) => token === "account" || token === "accounts" || token === "acct");
-  if (!hasAccountToken) {
-    return false;
-  }
-
-  const hasExcludedToken = tokens.some((token) => token.startsWith("accounting") || token.startsWith("unaccount"));
-  if (hasExcludedToken) {
-    return false;
-  }
-
-  const hasDateTimeToken = tokens.some((token) => DATE_TIME_INDICATOR_TOKENS.has(token));
-  if (hasDateTimeToken) {
-    return false;
-  }
-
-  return true;
-};
 
 const formatAccountDisplay = (rawValue?: string | null): string | null => {
   const segments = extractAccountSegments(rawValue);
@@ -121,184 +65,6 @@ const ensureRecord = (value: unknown): Record<string, unknown> | null => {
 const ensureArray = (value: unknown): unknown[] | null => {
   const parsed = parseJsonValue(value);
   return Array.isArray(parsed) ? parsed : null;
-};
-
-const coerceFieldValueToString = (value: unknown): string | undefined => {
-  if (isNonEmptyString(value)) {
-    return value.trim();
-  }
-
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(value);
-  }
-
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const coerced = coerceFieldValueToString(entry);
-      if (coerced) {
-        return coerced;
-      }
-    }
-    return undefined;
-  }
-
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const candidateKeys = ["value", "label", "name", "text", "display", "displayValue"] as const;
-    for (const key of candidateKeys) {
-      if (key in record) {
-        const coerced = coerceFieldValueToString(record[key]);
-        if (coerced) {
-          return coerced;
-        }
-      }
-    }
-  }
-
-  return undefined;
-};
-
-const ACCOUNT_KEY_PRIORITIES: Array<{ test: (key: string) => boolean; priority: number }> = [
-  {
-    test: (key) => /account[^a-z0-9]*display/i.test(key) || (/account/i.test(key) && /name/i.test(key)),
-    priority: 0,
-  },
-  {
-    test: (key) => /customer/i.test(key) && /name/i.test(key),
-    priority: 1,
-  },
-  {
-    test: (key) => /^account$/i.test(key) || /customer[^a-z0-9]*account/i.test(key),
-    priority: 2,
-  },
-  {
-    test: (key) => /account/i.test(key) && /number/i.test(key),
-    priority: 3,
-  },
-  {
-    test: (key) => /account/i.test(key) && /id/i.test(key),
-    priority: 4,
-  },
-  {
-    test: (key) => /account/i.test(key),
-    priority: 5,
-  },
-];
-
-const getAccountPriorityForKey = (keyHint?: string): number => {
-  if (!keyHint) {
-    return ACCOUNT_KEY_PRIORITIES.length;
-  }
-
-  const normalizedKey = keyHint.trim().toLowerCase();
-  for (const { test, priority } of ACCOUNT_KEY_PRIORITIES) {
-    if (test(normalizedKey)) {
-      return priority;
-    }
-  }
-
-  return ACCOUNT_KEY_PRIORITIES.length + 1;
-};
-
-type AccountSearchQueueEntry = {
-  value: unknown;
-  keyHint?: string;
-  fromAccountContext?: boolean;
-};
-
-const findAccountFieldValue = (
-  record?: Record<string, unknown>
-): string | undefined => {
-  if (!record) {
-    return undefined;
-  }
-
-  const visited = new Set<unknown>();
-  const queue: AccountSearchQueueEntry[] = [{ value: record }];
-  let bestCandidate: { value: string; priority: number } | null = null;
-
-  const considerCandidate = (value: unknown, keyHint?: string) => {
-    const stringValue = coerceFieldValueToString(value);
-    if (!stringValue) {
-      return;
-    }
-
-    if (ISO_DATE_PATTERN.test(stringValue)) {
-      return;
-    }
-
-    const segments = extractAccountSegments(stringValue);
-    if (segments.length === 0) {
-      return;
-    }
-
-    const prioritizedValue = segments[segments.length - 1];
-    const priority = getAccountPriorityForKey(keyHint);
-
-    if (!bestCandidate || priority < bestCandidate.priority || (priority === bestCandidate.priority && prioritizedValue !== bestCandidate.value)) {
-      bestCandidate = { value: prioritizedValue, priority };
-    }
-  };
-
-  while (queue.length > 0) {
-    const { value: current, keyHint, fromAccountContext } = queue.shift()!;
-
-    if (current === undefined || current === null) {
-      continue;
-    }
-
-    if (typeof current === "object") {
-      if (visited.has(current)) {
-        continue;
-      }
-      visited.add(current);
-    }
-
-    if (Array.isArray(current)) {
-      for (const entry of current) {
-        if (entry && typeof entry === "object" && !visited.has(entry)) {
-          queue.push({ value: entry, keyHint, fromAccountContext });
-        } else if (fromAccountContext || isLikelyAccountKey(keyHint)) {
-          considerCandidate(entry, keyHint);
-        }
-      }
-      continue;
-    }
-
-    if (typeof current === "object") {
-      const recordCandidate = current as Record<string, unknown>;
-
-      for (const [entryKey, value] of Object.entries(recordCandidate)) {
-        const keyIsAccount = isLikelyAccountKey(entryKey);
-        const nextKeyHint = keyIsAccount ? entryKey : keyHint;
-        const nextContext = Boolean(fromAccountContext || keyIsAccount);
-
-        if (keyIsAccount) {
-          considerCandidate(value, entryKey);
-        } else if (fromAccountContext && !value) {
-          continue;
-        }
-
-        if (value && typeof value === "object") {
-          if (!visited.has(value)) {
-            queue.push({ value, keyHint: nextKeyHint, fromAccountContext: nextContext });
-          }
-          continue;
-        }
-
-        if (nextContext) {
-          considerCandidate(value, nextKeyHint);
-        }
-      }
-      continue;
-    }
-
-    if (fromAccountContext || isLikelyAccountKey(keyHint)) {
-      considerCandidate(current, keyHint);
-    }
-  }
-
-  return bestCandidate?.value;
 };
 
 const QuoteManager = ({ user }: QuoteManagerProps) => {
@@ -422,10 +188,10 @@ const QuoteManager = ({ user }: QuoteManagerProps) => {
 
     const accountCandidates = [
       draftAccountFieldValue,
+      draftBomAccountFieldValue,
       combinedAccountFieldValue,
       configuredAccount,
       persistedAccountFieldValue,
-      draftBomAccountFieldValue,
       ...topLevelAccountCandidates,
       configuredCustomerName,
       normalizedDraftName,

--- a/src/utils/customerName.ts
+++ b/src/utils/customerName.ts
@@ -1,0 +1,271 @@
+type AnyRecord = Record<string, unknown>;
+
+export const extractAccountSegments = (rawValue?: string | null): string[] => {
+  if (!rawValue) {
+    return [];
+  }
+
+  return String(rawValue)
+    .split(/\r?\n+/)
+    .flatMap((segment) => segment.split(/[;,]+/))
+    .map((segment) => segment.replace(/^account\s*:?\s*/i, '').trim())
+    .filter(Boolean);
+};
+
+const normalizeKeyToTokens = (key: string): string[] =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_\-.]+/g, ' ')
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+
+const DATE_TIME_INDICATOR_TOKENS = new Set([
+  'date',
+  'time',
+  'expiration',
+  'expires',
+  'effective',
+  'start',
+  'end',
+  'timestamp',
+]);
+
+const ISO_DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})(?:[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+export const isLikelyAccountKey = (key: string | undefined): key is string => {
+  if (!key) {
+    return false;
+  }
+
+  const tokens = normalizeKeyToTokens(key);
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  const hasAccountToken = tokens.some((token) => token === 'account' || token === 'accounts' || token === 'acct');
+  if (!hasAccountToken) {
+    return false;
+  }
+
+  const hasExcludedToken = tokens.some((token) => token.startsWith('accounting') || token.startsWith('unaccount'));
+  if (hasExcludedToken) {
+    return false;
+  }
+
+  const hasDateTimeToken = tokens.some((token) => DATE_TIME_INDICATOR_TOKENS.has(token));
+  if (hasDateTimeToken) {
+    return false;
+  }
+
+  return true;
+};
+
+export const coerceFieldValueToString = (value: unknown): string | undefined => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const coerced = coerceFieldValueToString(entry);
+      if (coerced) {
+        return coerced;
+      }
+    }
+    return undefined;
+  }
+
+  if (value && typeof value === 'object') {
+    const record = value as AnyRecord;
+    const candidateKeys = ['value', 'label', 'name', 'text', 'display', 'displayValue'] as const;
+
+    for (const key of candidateKeys) {
+      if (key in record) {
+        const coerced = coerceFieldValueToString(record[key]);
+        if (coerced) {
+          return coerced;
+        }
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const ACCOUNT_KEY_PRIORITIES: Array<{ test: (key: string) => boolean; priority: number }> = [
+  {
+    test: (key) => /account[^a-z0-9]*display/i.test(key) || (/account/i.test(key) && /name/i.test(key)),
+    priority: 0,
+  },
+  {
+    test: (key) => /customer/i.test(key) && /name/i.test(key),
+    priority: 1,
+  },
+  {
+    test: (key) => /^account$/i.test(key) || /customer[^a-z0-9]*account/i.test(key),
+    priority: 2,
+  },
+  {
+    test: (key) => /account/i.test(key) && /number/i.test(key),
+    priority: 3,
+  },
+  {
+    test: (key) => /account/i.test(key) && /id/i.test(key),
+    priority: 4,
+  },
+  {
+    test: (key) => /account/i.test(key),
+    priority: 5,
+  },
+];
+
+const getAccountPriorityForKey = (keyHint?: string): number => {
+  if (!keyHint) {
+    return ACCOUNT_KEY_PRIORITIES.length;
+  }
+
+  const normalizedKey = keyHint.trim().toLowerCase();
+  for (const { test, priority } of ACCOUNT_KEY_PRIORITIES) {
+    if (test(normalizedKey)) {
+      return priority;
+    }
+  }
+
+  return ACCOUNT_KEY_PRIORITIES.length + 1;
+};
+
+type AccountSearchQueueEntry = {
+  value: unknown;
+  keyHint?: string;
+  fromAccountContext?: boolean;
+};
+
+export const findAccountFieldValue = (
+  record?: AnyRecord
+): string | undefined => {
+  if (!record) {
+    return undefined;
+  }
+
+  const visited = new Set<unknown>();
+  const queue: AccountSearchQueueEntry[] = [{ value: record }];
+  let bestCandidate: { value: string; priority: number } | null = null;
+
+  const considerCandidate = (value: unknown, keyHint?: string) => {
+    const stringValue = coerceFieldValueToString(value);
+    if (!stringValue) {
+      return;
+    }
+
+    if (ISO_DATE_PATTERN.test(stringValue)) {
+      return;
+    }
+
+    const segments = extractAccountSegments(stringValue);
+    if (segments.length === 0) {
+      return;
+    }
+
+    const prioritizedValue = segments[segments.length - 1];
+    const priority = getAccountPriorityForKey(keyHint);
+
+    if (!bestCandidate || priority < bestCandidate.priority) {
+      bestCandidate = { value: prioritizedValue, priority };
+      return;
+    }
+
+    if (
+      bestCandidate &&
+      priority === bestCandidate.priority &&
+      prioritizedValue.localeCompare(bestCandidate.value, undefined, { sensitivity: 'base' }) === 0
+    ) {
+      bestCandidate = { value: prioritizedValue, priority };
+    }
+  };
+
+  while (queue.length > 0) {
+    const { value: current, keyHint, fromAccountContext } = queue.shift()!;
+
+    if (current === undefined || current === null) {
+      continue;
+    }
+
+    if (typeof current === 'object') {
+      if (visited.has(current)) {
+        continue;
+      }
+      visited.add(current);
+    }
+
+    if (Array.isArray(current)) {
+      for (const entry of current) {
+        if (entry && typeof entry === 'object' && !visited.has(entry)) {
+          queue.push({ value: entry, keyHint, fromAccountContext });
+        } else if (fromAccountContext || isLikelyAccountKey(keyHint)) {
+          considerCandidate(entry, keyHint);
+        }
+      }
+      continue;
+    }
+
+    if (typeof current === 'object') {
+      const recordCandidate = current as AnyRecord;
+
+      for (const [entryKey, value] of Object.entries(recordCandidate)) {
+        const keyIsAccount = isLikelyAccountKey(entryKey);
+        const nextKeyHint = keyIsAccount ? entryKey : keyHint;
+        const nextContext = Boolean(fromAccountContext || keyIsAccount);
+
+        if (keyIsAccount) {
+          considerCandidate(value, entryKey);
+        } else if (fromAccountContext && !value) {
+          continue;
+        }
+
+        if (value && typeof value === 'object') {
+          if (!visited.has(value)) {
+            queue.push({ value, keyHint: nextKeyHint, fromAccountContext: nextContext });
+          }
+          continue;
+        }
+
+        if (nextContext) {
+          considerCandidate(value, nextKeyHint);
+        }
+      }
+      continue;
+    }
+
+    if (fromAccountContext || isLikelyAccountKey(keyHint)) {
+      considerCandidate(current, keyHint);
+    }
+  }
+
+  return bestCandidate?.value;
+};
+
+export const deriveCustomerNameFromFields = (
+  fields: Record<string, unknown> | null | undefined,
+  fallback?: string | null,
+): string | null => {
+  const accountValue = findAccountFieldValue(fields ?? undefined);
+  if (accountValue && accountValue.trim().length > 0) {
+    return accountValue.trim();
+  }
+
+  const directCustomer = coerceFieldValueToString((fields ?? {})['customer_name']);
+  if (directCustomer && directCustomer.trim().length > 0) {
+    return directCustomer.trim();
+  }
+
+  if (fallback && fallback.trim().length > 0) {
+    return fallback.trim();
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- add helpers to consistently derive customer names from quote fields and reuse them when creating, saving, autosaving, and submitting drafts so Supabase records stay in sync
- ensure quote submission rebuilds the BOM payload by clearing existing `bom_items` rows and inserting the latest configuration so admins receive the updated bill of materials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e520735844832689bf3a487d30b438