### PR TITLE
Refresh admin KPI dashboard and harden quote workflow claims

### DIFF
--- a/docs/ADMIN_KPI_AGING_REFRESH_PRD.md
+++ b/docs/ADMIN_KPI_AGING_REFRESH_PRD.md
@@ -1,0 +1,480 @@
+# Admin KPI Refresh PRD
+
+## Status
+- Draft
+- Date: 2026-04-23
+- Owner: Product / Admin Workflow
+
+## Summary
+Refresh the Admin KPI section into a simple, aging-first dashboard focused on one operational goal:
+
+Reduce approval wait time and prevent quotes from sitting unclaimed or unresolved.
+
+The new experience should prioritize:
+- Open quote age visibility
+- Ownership clarity
+- Unclaimed queue pressure
+- Reviewer throughput
+- Fast drilldown into stale cases
+
+This should replace the current KPI emphasis on broad averages and multi-tab reporting with a more action-oriented control tower for the approval workflow.
+
+## Problem
+The current KPI dashboard is informative, but it is not optimized for the most important operational question:
+
+Which quotes are aging right now, who owns them, and who is closing work?
+
+Current gaps:
+- Too much emphasis on averages and historical summaries
+- Not enough focus on open-case aging
+- No strong visual for unclaimed queue pressure
+- Per-user performance exists, but not in a simple "taken vs closed" operational board
+- No clear view that ties age buckets to either sales owner or queue owner
+- The dashboard does not feel like a live queue management tool
+
+## Goal
+Create a simple admin KPI dashboard that helps the team:
+- See how many quotes are still open
+- See how old those quotes are
+- See whether they are claimed or unclaimed
+- See who is owning the work
+- See who is closing work
+- Quickly identify stale approvals before they become customer response problems
+
+## Non-Goals
+- Full BI reporting replacement
+- Complex forecasting
+- Margin analytics redesign
+- Revenue-weighted executive reporting
+- Multi-page analytics experience
+
+## Primary Users
+- Admin reviewers
+- Finance reviewers
+- Master users
+- Secondary viewer: leadership checking queue health
+
+## Product Principles
+- Action over analysis
+- Open work first, history second
+- Aging is cumulative until final decision
+- Ownership must always be obvious
+- Unclaimed work must be highly visible
+- Mobile should remain readable, but desktop is the primary experience
+
+## Core Definitions
+
+### Approval Age
+- Approval age starts when the quote enters approval.
+- Use `submitted_at` as the primary start timestamp.
+- If `submitted_at` is missing, fall back to `created_at`.
+- Approval age continues increasing while the quote remains open.
+- Approval age stops only when the quote is finally `approved` or `rejected`.
+
+### Current Queue Owner
+- For normal approval flow:
+  - `admin_reviewer_id` if claimed
+  - otherwise `Unclaimed Admin Queue`
+- For finance-required flow:
+  - `finance_reviewer_id` if finance has claimed it
+  - otherwise `Unclaimed Finance Queue`
+
+### Sales Owner
+- The requestor / opportunity owner / submitter view
+- Use the existing submitter identity fields already shown in approval screens
+
+### Taken
+- Number of quotes claimed by a reviewer within the selected time range
+
+### Closed
+- Number of quotes finalized by that reviewer within the selected time range
+- Finalized means `approved` or `rejected`
+
+### Released To Finance
+- Number of quotes an admin reviewed and routed to finance because margin fell below the guardrail
+
+## Dashboard Outcome
+The refreshed dashboard should answer these questions within 10 seconds:
+- How many approval cases are open right now?
+- How many are over SLA?
+- How many are unclaimed?
+- Which age buckets are growing?
+- Who currently owns the queue?
+- Which reviewers are taking cases but not closing them?
+- Which cases need attention now?
+
+## Proposed Information Architecture
+
+### Top Row: Action KPIs
+Show 5 to 6 compact cards:
+- Open approvals
+- Over SLA
+- Unclaimed admin queue
+- Unclaimed finance queue
+- Median open age
+- Oldest open case
+
+Notes:
+- Prefer median over average for open age
+- Use strong color states:
+  - green = healthy
+  - amber = approaching SLA
+  - red = overdue
+
+### Main Left: Open Quotes by Age Bucket
+Primary chart on the page.
+
+Chart behavior:
+- Stacked bar chart
+- X-axis = age buckets
+- Y-axis = number of open quotes
+- Stack color = selected ownership mode
+
+Ownership modes:
+- Sales owner
+- Queue owner
+- Lane owner
+
+Default mode:
+- Queue owner
+
+Required bucket set for MVP:
+- 0-1 day
+- 1-2 days
+- 2-4 days
+- 4-7 days
+- 7-14 days
+- 14-30 days
+- 30+ days
+
+Visual behavior:
+- Modern, high-contrast, colorful
+- Rounded bars
+- Strong hover state
+- Clear legend
+- Smooth animation on filter changes
+- Red emphasis for oldest buckets
+
+Why this matters:
+- It immediately shows where aging is accumulating
+- It makes unclaimed queues impossible to ignore
+- It supports the user’s reference chart pattern while improving readability
+
+### Main Right: Reviewer Ownership Board
+Persistent board on the right side of desktop layout.
+
+Purpose:
+- Show how many cases each admin or finance reviewer took and closed
+- Surface who is overloaded, who is active, and who is leaving work to age
+
+Default columns:
+- Reviewer
+- Open owned
+- Taken
+- Closed
+- Approved
+- Rejected
+- Released to finance
+- Median close age
+- Over-SLA open cases
+
+Default sorting:
+- `Open owned` descending for live queue mode
+
+Optional alternate sorting:
+- `Closed` descending for performance review mode
+
+Special rows:
+- Unclaimed Admin Queue
+- Unclaimed Finance Queue
+
+## Supporting Section
+
+### Bottom Section: Cases Needing Attention
+Simple table showing the most urgent open quotes.
+
+Default columns:
+- Quote ID
+- Customer
+- Sales owner
+- Current queue owner
+- Current lane
+- Current age
+- Margin status
+- Claim status
+
+Default sort:
+- Oldest first
+
+Interaction:
+- Clicking a row should open the quote detail / approval page
+
+This is important because a dashboard without a direct path to action will still create delay.
+
+## Filters
+Keep filters simple and task-oriented.
+
+### Time Range
+- Today
+- Last 7 days
+- Last 30 days
+- Month to date
+- Custom range
+
+Use cases:
+- Open aging chart should always show current open queue state
+- Reviewer board should respect the selected range for taken/closed counts
+
+### Lane
+- All
+- Admin
+- Finance
+
+### Ownership Mode
+- Queue owner
+- Sales owner
+- Lane owner
+
+### Status Scope
+- Open only
+- Open + closed
+
+Default:
+- Open only
+
+## Data Model Rules
+
+### Open Aging Chart
+- Include only quotes that are not yet finally approved or rejected
+- Age continues from `submitted_at` through claim and through finance escalation
+- For finance-routed quotes, the total approval age still starts at the original approval entry timestamp
+
+### Queue-Specific Aging
+Use this as a secondary measure, not the primary headline:
+- Admin queue age starts at `submitted_at`
+- Finance queue age starts at `finance_required_at`
+
+Recommendation:
+- Keep total approval age as the primary KPI
+- Show queue-specific aging as a secondary tooltip or secondary badge
+
+### Owner Attribution Logic
+
+#### Queue Owner Mode
+- Open admin case claimed: show `admin_reviewer_id`
+- Open admin case unclaimed: `Unclaimed Admin Queue`
+- Open finance case claimed: show `finance_reviewer_id`
+- Open finance case unclaimed: `Unclaimed Finance Queue`
+
+#### Sales Owner Mode
+- Attribute by submitter / opportunity owner
+
+#### Reviewer Board
+- `Taken` = claim event in selected range
+- `Closed` = final decision in selected range
+- `Open owned` = currently open and currently assigned to that reviewer
+- `Released to finance` = admin decision `requires_finance`
+
+## UX Requirements
+- Desktop layout:
+  - left = age chart
+  - right = reviewer board
+- Mobile layout:
+  - cards first
+  - chart second
+  - board stacked below
+- No more than 2 primary charts on the page
+- The page should feel like a queue control center, not a reporting portal
+
+## Visual Direction
+- Dark-theme compatible
+- Brighter accent palette than current KPI page
+- Use a modern stacked chart style with bold saturation and subtle gradients
+- High readability first, but not plain
+- Aging buckets should visually intensify as risk increases
+
+Recommended color logic:
+- 0-2d family: blue / teal
+- 2-7d family: yellow / amber
+- 7-14d family: orange
+- 14+d family: red
+- 30+d family: deep red / magenta accent
+
+## Functional Requirements
+
+### Must Have
+- Open aging KPI cards
+- Stacked age bucket chart
+- Ownership mode toggle
+- Reviewer board on right side
+- Time filters including custom range
+- Lane filter
+- Unclaimed queue visibility
+- Oldest cases table
+
+### Should Have
+- Drilldown when clicking chart segment
+- Tooltip with quote count and impacted owners
+- Export current filtered dataset
+- Persist filter state in URL or local storage
+
+### Could Have
+- Value-weighted toggle
+- Product line filter
+- Department / region filter
+- Daily email digest of aging backlog
+
+## Suggested Improvements Beyond Current Request
+These are the most valuable additions if we want this dashboard to actually drive behavior:
+
+### 1. Median Age Over Average Age
+Averages hide outliers. Median makes open queue health more trustworthy.
+
+### 2. Unclaimed Queues As First-Class Entities
+Do not bury unclaimed items inside reviewer metrics. Show them as named queue owners.
+
+### 3. Oldest 10 Cases Panel
+This creates daily execution pressure and gives the team an obvious place to work from.
+
+### 4. Released-To-Finance Tracking
+This helps separate admin bottlenecks from finance bottlenecks.
+
+### 5. Claim-to-Close Conversion
+Useful follow-up metric:
+- cases taken
+- cases closed
+- open owned
+
+This reveals whether claims are actually resulting in throughput.
+
+### 6. Aging Heat State
+Each reviewer row should visually signal risk:
+- green = low aging
+- amber = moderate aging
+- red = too many over-SLA open cases
+
+### 7. Default To Open Queue
+Do not default to historical reporting. This page should open into "what needs action now."
+
+## Recommended MVP Scope
+
+### Phase 1: Aging Control Tower
+- Replace current KPI overview with new top cards
+- Add open aging stacked bar chart
+- Add reviewer board
+- Add oldest cases table
+- Add filters: lane, ownership mode, time range
+
+### Phase 2: Drilldown + Productivity Detail
+- Click-through filtering from chart and board
+- Add released-to-finance metric
+- Add per-reviewer detail drawer
+- Add export
+
+### Phase 3: Alerts + Management Enhancements
+- Daily stale queue digest
+- Aging threshold notifications
+- Compare current period vs previous period
+- Optional workload balancing indicators
+
+## Backend / Data Contract Recommendation
+The current KPI stack already has useful data in:
+- `quotes`
+- `quote_events`
+- `quote_kpi_facts`
+- `get_quote_kpi`
+
+Recommendation:
+- Keep the existing KPI service for historical metrics
+- Add a new focused payload for the aging dashboard instead of stretching the current structure too far
+
+Suggested payload shape:
+
+```ts
+type AgingDashboardPayload = {
+  summary: {
+    openCases: number;
+    overSla: number;
+    unclaimedAdmin: number;
+    unclaimedFinance: number;
+    medianOpenAgeSeconds: number | null;
+    oldestOpenAgeSeconds: number | null;
+  };
+  ageDistribution: Array<{
+    bucketKey: string;
+    bucketLabel: string;
+    total: number;
+    segments: Array<{
+      ownerKey: string;
+      ownerLabel: string;
+      count: number;
+    }>;
+  }>;
+  ownerBoard: Array<{
+    ownerKey: string;
+    ownerLabel: string;
+    ownerType: 'reviewer' | 'unclaimed_admin' | 'unclaimed_finance';
+    openOwned: number;
+    taken: number;
+    closed: number;
+    approved: number;
+    rejected: number;
+    releasedToFinance: number;
+    medianCloseAgeSeconds: number | null;
+    overSlaOpen: number;
+  }>;
+  oldestOpenCases: Array<{
+    quoteId: string;
+    customerName: string;
+    salesOwner: string | null;
+    queueOwner: string | null;
+    lane: 'admin' | 'finance';
+    ageSeconds: number;
+    isClaimed: boolean;
+    requiresFinanceApproval: boolean;
+  }>;
+};
+```
+
+## Frontend Recommendation
+Update the current KPI page in:
+- [src/components/admin/kpi/AdminKpiDashboard.tsx](/Users/carlosdeligi/Desktop/Git%20Projects/powerquotepro/src/components/admin/kpi/AdminKpiDashboard.tsx:1)
+
+Recommended approach:
+- Replace the current multi-tab KPI-heavy layout with a single-page operational dashboard
+- Keep at most one secondary section below the fold
+- Use `recharts` stacked bars for the first version
+- Add a compact board layout rather than a wide leaderboard table
+
+## Acceptance Criteria
+- Admin opens KPI page and sees open queue health immediately
+- User can switch grouping between sales owner and queue owner
+- Unclaimed admin and finance queues are visible without drilldown
+- Reviewer board shows taken and closed counts for selected period
+- Open age continues until final approval or rejection
+- Finance-routed quotes do not reset the main approval age
+- Clicking a stale bucket or owner filters to actionable cases
+
+## Success Metrics
+- Decrease count of open quotes over SLA
+- Decrease count of unclaimed quotes over 1 day old
+- Increase same-period close rate
+- Reduce median approval age
+- Increase percentage of open cases with active owner
+
+## Open Questions
+- Should sales owner use submitter, opportunity owner, or both when available?
+- Should master users appear in the same reviewer board as admins and finance?
+- Should the right-side board support both admin-only and finance-only ranking modes?
+- Do we want value-based overlays later, or keep this dashboard count-based only?
+
+## Recommendation
+Proceed with a focused MVP centered on:
+- open age
+- owner visibility
+- unclaimed queues
+- taken vs closed board
+
+That gives the team a cleaner operational dashboard and keeps the page aligned with the real business objective:
+
+Get quotes reviewed faster and do not let them sit aging without response.

--- a/src/components/admin/EnhancedQuoteApprovalDashboard.tsx
+++ b/src/components/admin/EnhancedQuoteApprovalDashboard.tsx
@@ -155,6 +155,9 @@ const isQuoteInQueue = (quote: Quote): boolean => {
   return WORKFLOW_QUEUE_STATES.has(state);
 };
 
+const canActInAdminLane = (role?: string | null) =>
+  role === 'ADMIN' || role === 'MASTER' || role === 'LEVEL_3';
+
 
 const getStatusBadge = (quote: Quote) => {
   const state = getDerivedWorkflowState(quote);
@@ -515,7 +518,7 @@ const EnhancedQuoteApprovalDashboard = ({ user }: EnhancedQuoteApprovalDashboard
       const isAdminLane = lane === 'admin';
       const isFinanceLane = lane === 'finance';
       const hasPermission = isAdminLane
-        ? userRole === 'ADMIN' || userRole === 'MASTER'
+        ? canActInAdminLane(userRole)
         : userRole === 'FINANCE' || userRole === 'MASTER';
 
       if (!hasPermission) {

--- a/src/components/admin/kpi/AdminKpiDashboard.tsx
+++ b/src/components/admin/kpi/AdminKpiDashboard.tsx
@@ -1,234 +1,938 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Input } from '@/components/ui/input';
+import { useNavigate } from 'react-router-dom';
+import { AlertTriangle, ArrowUpRight, CheckCheck, Clock3, RefreshCw, ShieldAlert, TimerReset, UserCircle2, Users } from 'lucide-react';
+import { ResponsiveContainer, BarChart, Bar, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { toast } from '@/components/ui/use-toast';
-import type { User } from '@/types/auth';
-import { kpiService, KpiBucket, KpiLane, KpiPayload, secondsToHours, secondsToDays, secondsToDaysDisplay } from '@/services/kpiService';
 import {
-  ResponsiveContainer,
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip,
-  CartesianGrid,
-  BarChart,
-  Bar,
-} from 'recharts';
+  kpiService,
+  type ApprovalAgingLane,
+  type ApprovalAgingOpenCase,
+  type ApprovalAgingPayload,
+} from '@/services/kpiService';
+import type { User } from '@/types/auth';
 
 interface Props {
   user: User;
 }
 
-const toDateInput = (d: Date) => d.toISOString().slice(0, 10);
-const pct = (num: number, den: number) => (den ? ((num / den) * 100).toFixed(1) : '0.0');
+type OwnerMode = 'queue_owner' | 'sales_owner' | 'lane_owner';
+type RangePreset = 'today' | '7d' | '30d' | 'mtd' | 'custom';
+type QuickFilter = 'all' | 'over_sla' | 'unclaimed_admin' | 'unclaimed_finance';
+
+type ChartSeries = {
+  key: string;
+  label: string;
+  color: string;
+  total: number;
+};
+
+const AGE_BUCKETS = [
+  { key: '0_1', label: '0-1d', minDays: 0, maxDays: 1 },
+  { key: '1_2', label: '1-2d', minDays: 1, maxDays: 2 },
+  { key: '2_4', label: '2-4d', minDays: 2, maxDays: 4 },
+  { key: '4_7', label: '4-7d', minDays: 4, maxDays: 7 },
+  { key: '7_14', label: '7-14d', minDays: 7, maxDays: 14 },
+  { key: '14_30', label: '14-30d', minDays: 14, maxDays: 30 },
+  { key: '30_plus', label: '30d+', minDays: 30, maxDays: Number.POSITIVE_INFINITY },
+] as const;
+
+const CHART_COLORS = [
+  '#38bdf8',
+  '#34d399',
+  '#fbbf24',
+  '#fb7185',
+  '#c084fc',
+  '#f97316',
+  '#22d3ee',
+  '#818cf8',
+  '#f472b6',
+];
+
+const toDateInput = (date: Date) => date.toISOString().slice(0, 10);
+
+const formatAgeCompact = (seconds?: number | null, fallback = '—') => {
+  if (seconds == null || !Number.isFinite(seconds)) return fallback;
+  const days = seconds / 86400;
+  if (days >= 10) return `${Math.round(days)}d`;
+  if (days >= 1) return `${days.toFixed(1)}d`;
+  const hours = seconds / 3600;
+  if (hours >= 1) return `${hours.toFixed(1)}h`;
+  return `${Math.max(0, Math.round(seconds / 60))}m`;
+};
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return '—';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return '—';
+  return parsed.toLocaleString();
+};
+
+const clampPositive = (value: number) => (Number.isFinite(value) && value > 0 ? value : 0);
+
+const getAgeDays = (ageSeconds: number) => ageSeconds / 86400;
+
+const getBucketForAge = (ageSeconds: number) => {
+  const ageDays = ageSeconds / 86400;
+  return AGE_BUCKETS.find((bucket) => ageDays >= bucket.minDays && ageDays < bucket.maxDays) ?? AGE_BUCKETS[AGE_BUCKETS.length - 1];
+};
+
+const getOwnerGrouping = (openCase: ApprovalAgingOpenCase, ownerMode: OwnerMode) => {
+  if (ownerMode === 'sales_owner') {
+    return {
+      key: `sales:${openCase.salesOwnerLabel}`,
+      label: openCase.salesOwnerLabel,
+    };
+  }
+
+  if (ownerMode === 'lane_owner') {
+    return {
+      key: `lane:${openCase.lane}`,
+      label: openCase.lane === 'finance' ? 'Finance Queue' : 'Admin Queue',
+    };
+  }
+
+  return {
+    key: `queue:${openCase.queueOwnerKey}`,
+    label: openCase.queueOwnerLabel,
+  };
+};
+
+const buildChartModel = (openCases: ApprovalAgingOpenCase[], ownerMode: OwnerMode) => {
+  const buckets = new Map<string, { bucketLabel: string; total: number; owners: Map<string, { label: string; count: number }> }>();
+  const ownerTotals = new Map<string, { label: string; total: number }>();
+
+  AGE_BUCKETS.forEach((bucket) => {
+    buckets.set(bucket.key, {
+      bucketLabel: bucket.label,
+      total: 0,
+      owners: new Map(),
+    });
+  });
+
+  openCases.forEach((openCase) => {
+    const bucket = getBucketForAge(openCase.ageSeconds);
+    const grouping = getOwnerGrouping(openCase, ownerMode);
+    const bucketData = buckets.get(bucket.key);
+    if (!bucketData) return;
+
+    bucketData.total += 1;
+    const current = bucketData.owners.get(grouping.key);
+    bucketData.owners.set(grouping.key, {
+      label: grouping.label,
+      count: (current?.count ?? 0) + 1,
+    });
+
+    const total = ownerTotals.get(grouping.key);
+    ownerTotals.set(grouping.key, {
+      label: grouping.label,
+      total: (total?.total ?? 0) + 1,
+    });
+  });
+
+  const sortedOwners = Array.from(ownerTotals.entries())
+    .sort((a, b) => b[1].total - a[1].total);
+
+  const visibleOwners = sortedOwners.slice(0, 8);
+  const hiddenOwnerKeys = new Set(sortedOwners.slice(8).map(([ownerKey]) => ownerKey));
+
+  const series: ChartSeries[] = visibleOwners.map(([ownerKey, owner], index) => ({
+    key: ownerKey,
+    label: owner.label,
+    color: CHART_COLORS[index % CHART_COLORS.length],
+    total: owner.total,
+  }));
+
+  if (hiddenOwnerKeys.size > 0) {
+    series.push({
+      key: 'other',
+      label: 'Other',
+      color: '#94a3b8',
+      total: sortedOwners.slice(8).reduce((sum, [, owner]) => sum + owner.total, 0),
+    });
+  }
+
+  const data = AGE_BUCKETS.map((bucket) => {
+    const bucketData = buckets.get(bucket.key)!;
+    const row: Record<string, string | number> = {
+      bucketLabel: bucketData.bucketLabel,
+      total: bucketData.total,
+    };
+
+    series.forEach((item) => {
+      row[item.key] = 0;
+    });
+
+    bucketData.owners.forEach((owner, ownerKey) => {
+      const key = hiddenOwnerKeys.has(ownerKey) ? 'other' : ownerKey;
+      row[key] = Number(row[key] || 0) + owner.count;
+    });
+
+    return row;
+  });
+
+  return { data, series };
+};
+
+const AgingChartTooltip = ({ active, payload, label }: any) => {
+  if (!active || !Array.isArray(payload) || payload.length === 0) return null;
+
+  const rows = payload
+    .filter((entry: any) => Number(entry.value) > 0)
+    .sort((a: any, b: any) => Number(b.value) - Number(a.value));
+
+  if (!rows.length) return null;
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/95 px-4 py-3 shadow-2xl backdrop-blur">
+      <div className="mb-2 text-xs uppercase tracking-[0.18em] text-slate-400">{label}</div>
+      <div className="space-y-1.5">
+        {rows.map((entry: any) => (
+          <div key={entry.dataKey} className="flex min-w-[180px] items-center justify-between gap-4 text-sm">
+            <div className="flex items-center gap-2 text-slate-200">
+              <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: entry.color }} />
+              <span>{entry.name}</span>
+            </div>
+            <span className="font-semibold text-white">{entry.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const getOpenCaseSeverity = (openCase: ApprovalAgingOpenCase, slaDays: number) => {
+  const ageDays = getAgeDays(openCase.ageSeconds);
+
+  if (ageDays >= Math.max(slaDays * 2, 14)) {
+    return {
+      rowClass: 'bg-rose-500/[0.09] hover:bg-rose-500/[0.14]',
+      ageClass: 'border-rose-400/40 bg-rose-400/15 text-rose-200',
+      accentClass: 'bg-rose-400',
+      label: 'Critical',
+    };
+  }
+
+  if (ageDays >= slaDays) {
+    return {
+      rowClass: 'bg-amber-500/[0.08] hover:bg-amber-500/[0.14]',
+      ageClass: 'border-amber-400/40 bg-amber-400/15 text-amber-200',
+      accentClass: 'bg-amber-300',
+      label: 'Over SLA',
+    };
+  }
+
+  if (!openCase.isClaimed) {
+    return {
+      rowClass: 'bg-orange-500/[0.06] hover:bg-orange-500/[0.11]',
+      ageClass: 'border-orange-400/35 bg-orange-400/10 text-orange-200',
+      accentClass: 'bg-orange-300',
+      label: 'Unclaimed',
+    };
+  }
+
+  return {
+    rowClass: 'bg-transparent hover:bg-white/[0.05]',
+    ageClass: 'border-sky-400/25 bg-sky-400/10 text-sky-100',
+    accentClass: 'bg-emerald-300',
+    label: 'Healthy',
+  };
+};
 
 export default function AdminKpiDashboard({ user }: Props) {
-  const [lane, setLane] = useState<KpiLane>('both');
-  const [bucket, setBucket] = useState<KpiBucket>('day');
-  const [rangePreset, setRangePreset] = useState<'7' | '14' | '30' | '90' | 'custom'>('30');
+  const navigate = useNavigate();
+  const [lane, setLane] = useState<ApprovalAgingLane>('all');
+  const [ownerMode, setOwnerMode] = useState<OwnerMode>('queue_owner');
+  const [rangePreset, setRangePreset] = useState<RangePreset>('30d');
   const [startDate, setStartDate] = useState(toDateInput(new Date(Date.now() - 30 * 86400000)));
   const [endDate, setEndDate] = useState(toDateInput(new Date()));
   const [slaDays, setSlaDays] = useState(2);
   const [loading, setLoading] = useState(false);
-  const [payload, setPayload] = useState<KpiPayload | null>(null);
-  const [userMap, setUserMap] = useState<Record<string, { name: string; email: string; role: string }>>({});
-  const [tab, setTab] = useState('overview');
+  const [payload, setPayload] = useState<ApprovalAgingPayload | null>(null);
+  const [focusedOwnerKey, setFocusedOwnerKey] = useState<string | null>(null);
+  const [quickFilter, setQuickFilter] = useState<QuickFilter>('all');
 
   useEffect(() => {
-    kpiService.getDefaultSlaHours().then((hours) => setSlaDays(Math.max(1, Math.round(hours / 24)))).catch(() => null);
+    kpiService
+      .getDefaultSlaHours()
+      .then((hours) => setSlaDays(Math.max(1, Math.round(hours / 24))))
+      .catch(() => null);
   }, []);
 
   useEffect(() => {
     if (rangePreset === 'custom') return;
-    const days = Number(rangePreset);
-    setStartDate(toDateInput(new Date(Date.now() - days * 86400000)));
-    setEndDate(toDateInput(new Date()));
+
+    const now = new Date();
+    const nextEnd = toDateInput(now);
+
+    if (rangePreset === 'today') {
+      setStartDate(toDateInput(now));
+      setEndDate(nextEnd);
+      return;
+    }
+
+    if (rangePreset === '7d') {
+      setStartDate(toDateInput(new Date(Date.now() - 7 * 86400000)));
+      setEndDate(nextEnd);
+      return;
+    }
+
+    if (rangePreset === '30d') {
+      setStartDate(toDateInput(new Date(Date.now() - 30 * 86400000)));
+      setEndDate(nextEnd);
+      return;
+    }
+
+    const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+    setStartDate(toDateInput(monthStart));
+    setEndDate(nextEnd);
   }, [rangePreset]);
 
   const load = async () => {
     try {
       setLoading(true);
-      const data = await kpiService.getKpiMetrics({
+      const nextPayload = await kpiService.getApprovalAgingDashboard({
         start: new Date(`${startDate}T00:00:00Z`),
         end: new Date(`${endDate}T23:59:59Z`),
-        bucket,
         lane,
         slaHours: Math.max(1, slaDays) * 24,
       });
-      setPayload(data);
-
-      const ids = Array.from(new Set((data.per_user || []).map((r) => r.user_id).filter(Boolean))) as string[];
-      const users = await kpiService.resolveUsers(ids);
-      setUserMap(users);
+      setPayload(nextPayload);
     } catch (error: any) {
-      toast({ title: 'KPI error', description: error?.message || 'Failed to load KPI data.', variant: 'destructive' });
+      toast({
+        title: 'KPI error',
+        description: error?.message || 'Failed to load approval aging metrics.',
+        variant: 'destructive',
+      });
     } finally {
       setLoading(false);
     }
   };
 
   useEffect(() => {
+    setFocusedOwnerKey(null);
+  }, [ownerMode, lane]);
+
+  useEffect(() => {
+    setQuickFilter('all');
+  }, [lane, startDate, endDate, slaDays]);
+
+  useEffect(() => {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lane, bucket, startDate, endDate, slaDays]);
+  }, [lane, startDate, endDate, slaDays]);
 
-  const leaderboard = useMemo(() => {
-    const rows = (payload?.per_user || []).map((r) => ({
-      ...r,
-      user_name: r.user_id ? (userMap[r.user_id]?.name || userMap[r.user_id]?.email || r.user_id) : 'Unassigned',
-      otd: Number(pct(r.met_sla || 0, r.considered_sla || 0)),
-      avg_claim_d: secondsToDaysDisplay(r.avg_claim_seconds),
-      avg_work_d: secondsToDaysDisplay(r.avg_work_seconds),
-      avg_cycle_d: secondsToDaysDisplay(r.avg_cycle_seconds),
-    }));
+  const openCases = payload?.openCases ?? [];
+  const quickFilteredCases = useMemo(() => {
+    switch (quickFilter) {
+      case 'over_sla':
+        return openCases.filter((openCase) => getAgeDays(openCase.ageSeconds) >= slaDays);
+      case 'unclaimed_admin':
+        return openCases.filter((openCase) => openCase.lane === 'admin' && !openCase.isClaimed);
+      case 'unclaimed_finance':
+        return openCases.filter((openCase) => openCase.lane === 'finance' && !openCase.isClaimed);
+      default:
+        return openCases;
+    }
+  }, [openCases, quickFilter, slaDays]);
 
-    return rows.sort((a, b) => {
-      const completed = (b.completed || 0) - (a.completed || 0);
-      if (completed !== 0) return completed;
-      const otd = (b.otd || 0) - (a.otd || 0);
-      if (otd !== 0) return otd;
-      const aCycle = Number(a.avg_cycle_seconds ?? Infinity);
-      const bCycle = Number(b.avg_cycle_seconds ?? Infinity);
-      return aCycle - bCycle;
-    });
-  }, [payload?.per_user, userMap]);
+  const { data: chartData, series: chartSeries } = useMemo(
+    () => buildChartModel(quickFilteredCases, ownerMode),
+    [quickFilteredCases, ownerMode],
+  );
 
-  const ts = (payload?.timeseries || []).map((r) => ({
-    bucket: String(r.bucket_start).slice(0, 10),
-    submitted: r.submitted,
-    completed: r.completed,
-    avgCycleD: secondsToDays(r.avg_cycle_seconds),
-    otd: Number(pct(r.met_sla || 0, r.considered_sla || 0)),
-  }));
+  const ownerBoard = useMemo(
+    () => (payload?.ownerBoard ?? []).slice().sort((a, b) => {
+      const openDiff = b.openOwned - a.openOwned;
+      if (openDiff !== 0) return openDiff;
 
-  const s = payload?.summary;
-  const backlogAdmin = payload?.backlog?.admin;
-  const backlogFinance = payload?.backlog?.finance;
-  const backlogThresholdDays = Number(Math.max(1, slaDays).toFixed(1));
+      const overSlaDiff = b.overSlaOpen - a.overSlaOpen;
+      if (overSlaDiff !== 0) return overSlaDiff;
+
+      return b.closed - a.closed;
+    }),
+    [payload?.ownerBoard],
+  );
+
+  const visibleCases = useMemo(() => {
+    if (!focusedOwnerKey) return quickFilteredCases;
+
+    return quickFilteredCases.filter((openCase) => getOwnerGrouping(openCase, ownerMode).key === focusedOwnerKey);
+  }, [focusedOwnerKey, quickFilteredCases, ownerMode]);
+
+  const oldestCases = useMemo(
+    () => visibleCases.slice().sort((a, b) => b.ageSeconds - a.ageSeconds).slice(0, 12),
+    [visibleCases],
+  );
+
+  const summary = payload?.summary;
+
+  const summaryCards = [
+    {
+      key: 'open',
+      title: 'Open Approvals',
+      value: String(summary?.openCases ?? 0),
+      detail: 'Current cases still waiting for a final decision',
+      filter: 'all' as QuickFilter,
+      interactive: true,
+      icon: TimerReset,
+      accent: 'from-sky-500/20 via-cyan-400/10 to-transparent',
+      valueClass: 'text-sky-300',
+    },
+    {
+      key: 'sla',
+      title: 'Over SLA',
+      value: String(summary?.overSla ?? 0),
+      detail: `Cases older than ${slaDays} days`,
+      filter: 'over_sla' as QuickFilter,
+      interactive: true,
+      icon: AlertTriangle,
+      accent: 'from-rose-500/20 via-orange-400/10 to-transparent',
+      valueClass: 'text-rose-300',
+    },
+    {
+      key: 'admin-unclaimed',
+      title: 'Unclaimed Admin',
+      value: String(summary?.unclaimedAdmin ?? 0),
+      detail: 'Open admin reviews with no current owner',
+      filter: 'unclaimed_admin' as QuickFilter,
+      interactive: true,
+      icon: UserCircle2,
+      accent: 'from-amber-500/20 via-yellow-400/10 to-transparent',
+      valueClass: 'text-amber-300',
+    },
+    {
+      key: 'finance-unclaimed',
+      title: 'Unclaimed Finance',
+      value: String(summary?.unclaimedFinance ?? 0),
+      detail: 'Finance queue waiting for someone to take it',
+      filter: 'unclaimed_finance' as QuickFilter,
+      interactive: true,
+      icon: ShieldAlert,
+      accent: 'from-fuchsia-500/20 via-pink-400/10 to-transparent',
+      valueClass: 'text-fuchsia-300',
+    },
+    {
+      key: 'median',
+      title: 'Median Open Age',
+      value: formatAgeCompact(summary?.medianOpenAgeSeconds),
+      detail: 'More reliable than average when outliers exist',
+      filter: 'all' as QuickFilter,
+      interactive: false,
+      icon: Clock3,
+      accent: 'from-emerald-500/20 via-teal-400/10 to-transparent',
+      valueClass: 'text-emerald-300',
+    },
+    {
+      key: 'oldest',
+      title: 'Oldest Open Case',
+      value: formatAgeCompact(summary?.oldestOpenAgeSeconds),
+      detail: 'The single case at highest response risk',
+      filter: 'all' as QuickFilter,
+      interactive: false,
+      icon: Users,
+      accent: 'from-violet-500/20 via-indigo-400/10 to-transparent',
+      valueClass: 'text-violet-300',
+    },
+  ];
+
+  const quickFilterLabel = (
+    quickFilter === 'over_sla'
+      ? `Over SLA · ${quickFilteredCases.length} case${quickFilteredCases.length === 1 ? '' : 's'}`
+      : quickFilter === 'unclaimed_admin'
+        ? `Unclaimed Admin Queue · ${quickFilteredCases.length} case${quickFilteredCases.length === 1 ? '' : 's'}`
+        : quickFilter === 'unclaimed_finance'
+          ? `Unclaimed Finance Queue · ${quickFilteredCases.length} case${quickFilteredCases.length === 1 ? '' : 's'}`
+          : null
+  );
 
   return (
-    <div className="space-y-4">
-      <div className="text-gray-300 text-sm">KPI Dashboard · {user.name}</div>
-      <div className="flex flex-wrap items-end gap-3">
-        <div>
-          <Label className="text-gray-300">Lane</Label>
-          <Select value={lane} onValueChange={(v: KpiLane) => setLane(v)}>
-            <SelectTrigger className="w-[130px] bg-gray-800 border-gray-700 text-white"><SelectValue /></SelectTrigger>
-            <SelectContent className="bg-gray-800 border-gray-700 text-white">
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="both">Both</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="admin">Admin</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="finance">Finance</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div>
-          <Label className="text-gray-300">Bucket</Label>
-          <Select value={bucket} onValueChange={(v: KpiBucket) => setBucket(v)}>
-            <SelectTrigger className="w-[130px] bg-gray-800 border-gray-700 text-white"><SelectValue /></SelectTrigger>
-            <SelectContent className="bg-gray-800 border-gray-700 text-white">
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="day">Day</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="week">Week</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="biweek">Biweekly</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="month">Month</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div>
-          <Label className="text-gray-300">Range</Label>
-          <Select value={rangePreset} onValueChange={(v: any) => setRangePreset(v)}>
-            <SelectTrigger className="w-[140px] bg-gray-800 border-gray-700 text-white"><SelectValue /></SelectTrigger>
-            <SelectContent className="bg-gray-800 border-gray-700 text-white">
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="7">Last 7d</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="14">Last 14d</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="30">Last 30d</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="90">Last 90d</SelectItem>
-              <SelectItem className="text-white data-[highlighted]:bg-gray-700 data-[highlighted]:text-white" value="custom">Custom</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div>
-          <Label className="text-gray-300">Start</Label>
-          <Input type="date" value={startDate} onChange={(e) => { setRangePreset('custom'); setStartDate(e.target.value); }} className="bg-gray-800 border-gray-700 text-white" />
-        </div>
-        <div>
-          <Label className="text-gray-300">End</Label>
-          <Input type="date" value={endDate} onChange={(e) => { setRangePreset('custom'); setEndDate(e.target.value); }} className="bg-gray-800 border-gray-700 text-white" />
-        </div>
-        <div>
-          <Label className="text-gray-300">SLA Days</Label>
-          <Input type="number" min={1} value={slaDays} onChange={(e) => setSlaDays(Number(e.target.value || 2))} className="w-[110px] bg-gray-800 border-gray-700 text-white" />
-        </div>
-        <Button className="bg-red-600 hover:bg-red-700" onClick={async () => { try { await kpiService.saveDefaultSlaHours(Math.max(1, slaDays) * 24); toast({ title: 'Saved', description: 'Default SLA updated.' }); } catch (e: any) { toast({ title: 'Error', description: e?.message || 'Could not save SLA', variant: 'destructive' }); } }}>
-          Save as default
-        </Button>
+    <div className="space-y-5">
+      <Card className="overflow-hidden border-white/10 bg-[linear-gradient(135deg,rgba(2,6,23,0.98),rgba(15,23,42,0.95)_55%,rgba(30,41,59,0.92))] text-white shadow-2xl">
+        <CardContent className="p-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-3">
+              <div className="inline-flex items-center gap-2 rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.22em] text-sky-200">
+                Approval Aging Control Tower
+              </div>
+              <div>
+                <h2 className="text-3xl font-semibold tracking-tight text-white">Get cases reviewed before they get old.</h2>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
+                  This dashboard keeps the clock running from the moment a quote enters approval until final approve or reject.
+                  It is built to expose aging, unclaimed work, and who is actually moving cases to closure.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-300">
+              <Badge className="border border-emerald-400/30 bg-emerald-400/10 text-emerald-200">
+                Open Queue Now
+              </Badge>
+              <Badge className="border border-white/10 bg-white/5 text-slate-200">
+                Activity Range: {rangePreset === 'today' ? 'Today' : rangePreset === '7d' ? 'Last 7 days' : rangePreset === '30d' ? 'Last 30 days' : rangePreset === 'mtd' ? 'Month to date' : 'Custom'}
+              </Badge>
+              <span className="text-slate-400">Updated {formatDateTime(payload?.generatedAt)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/10 bg-slate-950/80 text-white shadow-xl">
+        <CardContent className="p-5">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
+            <div>
+              <Label className="text-xs uppercase tracking-[0.18em] text-slate-400">Lane</Label>
+              <Select value={lane} onValueChange={(value: ApprovalAgingLane) => setLane(value)}>
+                <SelectTrigger className="mt-2 border-white/10 bg-slate-900 text-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-slate-900 text-white">
+                  <SelectItem value="all">All lanes</SelectItem>
+                  <SelectItem value="admin">Admin only</SelectItem>
+                  <SelectItem value="finance">Finance only</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label className="text-xs uppercase tracking-[0.18em] text-slate-400">Color By</Label>
+              <Select value={ownerMode} onValueChange={(value: OwnerMode) => setOwnerMode(value)}>
+                <SelectTrigger className="mt-2 border-white/10 bg-slate-900 text-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-slate-900 text-white">
+                  <SelectItem value="queue_owner">Queue owner</SelectItem>
+                  <SelectItem value="sales_owner">Sales owner</SelectItem>
+                  <SelectItem value="lane_owner">Lane owner</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label className="text-xs uppercase tracking-[0.18em] text-slate-400">Activity Range</Label>
+              <Select value={rangePreset} onValueChange={(value: RangePreset) => setRangePreset(value)}>
+                <SelectTrigger className="mt-2 border-white/10 bg-slate-900 text-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-slate-900 text-white">
+                  <SelectItem value="today">Today</SelectItem>
+                  <SelectItem value="7d">Last 7 days</SelectItem>
+                  <SelectItem value="30d">Last 30 days</SelectItem>
+                  <SelectItem value="mtd">Month to date</SelectItem>
+                  <SelectItem value="custom">Custom</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label className="text-xs uppercase tracking-[0.18em] text-slate-400">Start</Label>
+              <Input
+                type="date"
+                value={startDate}
+                onChange={(event) => {
+                  setRangePreset('custom');
+                  setStartDate(event.target.value);
+                }}
+                className="mt-2 border-white/10 bg-slate-900 text-white"
+              />
+            </div>
+
+            <div>
+              <Label className="text-xs uppercase tracking-[0.18em] text-slate-400">End</Label>
+              <Input
+                type="date"
+                value={endDate}
+                onChange={(event) => {
+                  setRangePreset('custom');
+                  setEndDate(event.target.value);
+                }}
+                className="mt-2 border-white/10 bg-slate-900 text-white"
+              />
+            </div>
+
+            <div>
+              <Label className="text-xs uppercase tracking-[0.18em] text-slate-400">SLA Days</Label>
+              <div className="mt-2 flex gap-2">
+                <Input
+                  type="number"
+                  min={1}
+                  value={slaDays}
+                  onChange={(event) => setSlaDays(clampPositive(Number(event.target.value || 2)) || 2)}
+                  className="border-white/10 bg-slate-900 text-white"
+                />
+                <Button
+                  variant="outline"
+                  className="border-white/10 bg-white/5 text-white hover:bg-white/10"
+                  onClick={async () => {
+                    try {
+                      await kpiService.saveDefaultSlaHours(Math.max(1, slaDays) * 24);
+                      toast({ title: 'Saved', description: 'Default KPI SLA updated.' });
+                    } catch (error: any) {
+                      toast({
+                        title: 'Error',
+                        description: error?.message || 'Could not save KPI SLA.',
+                        variant: 'destructive',
+                      });
+                    }
+                  }}
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <Button
+              onClick={load}
+              disabled={loading}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+              {loading ? 'Refreshing...' : 'Refresh dashboard'}
+            </Button>
+            {focusedOwnerKey && (
+              <Button
+                variant="outline"
+                className="border-white/10 bg-white/5 text-white hover:bg-white/10"
+                onClick={() => setFocusedOwnerKey(null)}
+              >
+                Clear owner focus
+              </Button>
+            )}
+            {quickFilter !== 'all' && (
+              <Button
+                variant="outline"
+                className="border-white/10 bg-white/5 text-white hover:bg-white/10"
+                onClick={() => setQuickFilter('all')}
+              >
+                Clear KPI filter
+              </Button>
+            )}
+            <span className="text-xs text-slate-400">
+              Open age never pauses. It stops only when the quote is approved or rejected.
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
+        {summaryCards.map((item) => {
+          const Icon = item.icon;
+          const isActive = item.interactive && quickFilter === item.filter;
+
+          return (
+            <button
+              key={item.key}
+              type="button"
+              disabled={!item.interactive}
+              onClick={() => {
+                if (!item.interactive) return;
+                setFocusedOwnerKey(null);
+                setQuickFilter(item.filter);
+              }}
+              className={`h-full w-full text-left ${item.key === 'median' || item.key === 'oldest' ? 'md:col-span-1' : 'md:col-span-1'} ${item.interactive ? 'cursor-pointer' : 'cursor-default'}`}
+            >
+              <Card
+                className={`h-full min-h-[220px] overflow-hidden border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.98),rgba(2,6,23,0.96))] text-white shadow-xl transition ${item.interactive ? 'hover:-translate-y-0.5 hover:border-white/20 hover:shadow-2xl' : ''} ${isActive ? 'border-sky-400/50 ring-1 ring-sky-400/30' : ''}`}
+              >
+                <CardContent className="relative flex h-full flex-col p-5">
+                  <div className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${item.accent}`} />
+                  <div className="relative flex h-full flex-col">
+                    <div className="flex items-start justify-between">
+                      <div>
+                        <div className="text-xs uppercase tracking-[0.18em] text-slate-400">{item.title}</div>
+                        <div className={`mt-4 text-4xl font-semibold tracking-tight ${item.valueClass}`}>{item.value}</div>
+                      </div>
+                      <div className="rounded-xl border border-white/10 bg-white/5 p-2">
+                        <Icon className="h-5 w-5 text-white" />
+                      </div>
+                    </div>
+                    <p className="mt-4 min-h-[3rem] text-sm leading-6 text-slate-300">{item.detail}</p>
+                    <div className="mt-auto pt-4 flex items-center justify-between text-xs">
+                      <span className={item.interactive ? 'text-slate-300' : 'text-slate-500'}>
+                        {item.interactive ? (isActive ? 'Filter active' : 'Click to focus') : 'Insight card'}
+                      </span>
+                      {item.interactive && (
+                        <span className={`rounded-full border px-2 py-1 ${isActive ? 'border-sky-400/40 bg-sky-400/15 text-sky-200' : 'border-white/10 bg-white/5 text-slate-400'}`}>
+                          {isActive ? 'Focused' : 'Ready'}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </button>
+          );
+        })}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-3">
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">OTD ≤ SLA</CardTitle></CardHeader><CardContent className="text-2xl text-green-400">{pct(s?.met_sla || 0, s?.considered_sla || 0)}%</CardContent></Card>
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">Avg Cycle (d)</CardTitle></CardHeader><CardContent className="text-2xl text-white">{secondsToDaysDisplay(s?.avg_total_cycle_seconds)}</CardContent></Card>
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">Avg Admin Claim (d)</CardTitle></CardHeader><CardContent className="text-2xl text-white">{secondsToDaysDisplay(s?.avg_admin_claim_seconds)}</CardContent></Card>
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">Avg Admin Work (d)</CardTitle></CardHeader><CardContent className="text-2xl text-white">{secondsToDaysDisplay(s?.avg_admin_work_seconds)}</CardContent></Card>
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">Avg Finance Claim (d)</CardTitle></CardHeader><CardContent className="text-2xl text-white">{secondsToDaysDisplay(s?.avg_finance_claim_seconds)}</CardContent></Card>
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">Avg Finance Work (d)</CardTitle></CardHeader><CardContent className="text-2xl text-white">{secondsToDaysDisplay(s?.avg_finance_work_seconds)}</CardContent></Card>
-      </div>
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <Card className="overflow-hidden border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.98),rgba(2,6,23,0.97))] text-white shadow-2xl xl:col-span-8">
+          <CardHeader className="border-b border-white/10 pb-4">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <div className="text-xs uppercase tracking-[0.18em] text-slate-400">Open quotes vs age</div>
+                <CardTitle className="mt-2 text-2xl text-white">Where the queue is getting old</CardTitle>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  Stack color can flip between current queue owner, sales owner, or lane owner so you can see who is carrying the aging inventory.
+                </p>
+              </div>
+              <div className="text-right text-xs text-slate-400">
+                <div>{quickFilteredCases.length} open case{quickFilteredCases.length === 1 ? '' : 's'} in view</div>
+                <div>{summary?.overSla ?? 0} already over SLA</div>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="p-5">
+            {quickFilterLabel && (
+              <div className="mb-4 flex flex-wrap items-center gap-2">
+                <Badge className="border border-sky-400/35 bg-sky-400/10 text-sky-200">
+                  {quickFilterLabel}
+                </Badge>
+                <span className="text-xs text-slate-400">Top KPI cards now act as instant queue filters.</span>
+              </div>
+            )}
+            {loading ? (
+              <div className="flex h-[380px] items-center justify-center text-slate-400">Loading chart...</div>
+            ) : quickFilteredCases.length === 0 ? (
+              <div className="flex h-[380px] flex-col items-center justify-center gap-2 text-center text-slate-400">
+                <CheckCheck className="h-10 w-10 text-emerald-300" />
+                <div className="text-lg font-medium text-white">No open approvals in this view</div>
+                <div className="max-w-md text-sm">The queue is clear for the selected lane filter. Change the lane or refresh if you expect active work.</div>
+              </div>
+            ) : (
+              <>
+                <div className="h-[380px]">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={chartData} barCategoryGap="18%">
+                      <CartesianGrid vertical={false} strokeDasharray="3 3" stroke="#243246" />
+                      <XAxis dataKey="bucketLabel" stroke="#94a3b8" tickLine={false} axisLine={false} />
+                      <YAxis allowDecimals={false} stroke="#94a3b8" tickLine={false} axisLine={false} />
+                      <Tooltip content={<AgingChartTooltip />} cursor={{ fill: 'rgba(148,163,184,0.08)' }} />
+                      {chartSeries.map((item) => (
+                        <Bar
+                          key={item.key}
+                          dataKey={item.key}
+                          name={item.label}
+                          stackId="age"
+                          fill={item.color}
+                          radius={[10, 10, 0, 0]}
+                        />
+                      ))}
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">Admin Backlog / &gt;SLA / Avg Age(d)</CardTitle></CardHeader><CardContent className="text-gray-200">{backlogAdmin?.backlog || 0} / {backlogAdmin?.backlog_over_sla || 0} / {secondsToDaysDisplay(backlogAdmin?.avg_age_seconds)}</CardContent></Card>
-        <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white text-sm">Finance Backlog / &gt;SLA / Avg Age(d)</CardTitle></CardHeader><CardContent className="text-gray-200">{backlogFinance?.backlog || 0} / {backlogFinance?.backlog_over_sla || 0} / {secondsToDaysDisplay(backlogFinance?.avg_age_seconds)}</CardContent></Card>
-      </div>
-
-      <Tabs value={tab} onValueChange={setTab} className="w-full">
-        <TabsList className="bg-gray-800 w-full flex overflow-x-auto whitespace-nowrap h-auto p-1 gap-1">
-          <TabsTrigger value="overview" className="shrink-0 text-white data-[state=active]:bg-red-600">Overview</TabsTrigger>
-          <TabsTrigger value="admin" className="shrink-0 text-white data-[state=active]:bg-red-600">Admin Lane</TabsTrigger>
-          <TabsTrigger value="finance" className="shrink-0 text-white data-[state=active]:bg-red-600">Finance Lane</TabsTrigger>
-          <TabsTrigger value="leaderboard" className="shrink-0 text-white data-[state=active]:bg-red-600">Leaderboard</TabsTrigger>
-          <TabsTrigger value="backlog" className="shrink-0 text-white data-[state=active]:bg-red-600">Backlog</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="overview" className="space-y-4">
-          <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white">Average Cycle Time Trend (d)</CardTitle></CardHeader><CardContent className="h-72">{loading ? <div className="text-gray-400">Loading...</div> : <ResponsiveContainer width="100%" height="100%"><LineChart data={ts}><CartesianGrid strokeDasharray="3 3" stroke="#334155" /><XAxis dataKey="bucket" stroke="#94a3b8" /><YAxis stroke="#94a3b8" /><Tooltip /><Line type="monotone" dataKey="avgCycleD" stroke="#22c55e" strokeWidth={2} /></LineChart></ResponsiveContainer>}</CardContent></Card>
-          <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white">Completed vs Submitted</CardTitle></CardHeader><CardContent className="h-72">{loading ? <div className="text-gray-400">Loading...</div> : <ResponsiveContainer width="100%" height="100%"><BarChart data={ts}><CartesianGrid strokeDasharray="3 3" stroke="#334155" /><XAxis dataKey="bucket" stroke="#94a3b8" /><YAxis stroke="#94a3b8" /><Tooltip /><Bar dataKey="submitted" fill="#64748b" /><Bar dataKey="completed" fill="#ef4444" /></BarChart></ResponsiveContainer>}</CardContent></Card>
-        </TabsContent>
-
-        <TabsContent value="admin"><Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white">Admin lane focus</CardTitle></CardHeader><CardContent className="text-gray-300">Use lane filter = Admin to isolate claim/work bottlenecks before finance handoff.</CardContent></Card></TabsContent>
-        <TabsContent value="finance"><Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white">Finance lane focus</CardTitle></CardHeader><CardContent className="text-gray-300">Use lane filter = Finance to isolate queueing after finance_required_at and processing time after claim.</CardContent></Card></TabsContent>
-
-        <TabsContent value="leaderboard">
-          <Card className="bg-gray-900 border-gray-800">
-            <CardHeader><CardTitle className="text-white">Productivity Ranking by User</CardTitle></CardHeader>
-            <CardContent className="overflow-x-auto">
-              <table className="w-full text-sm text-left">
-                <thead className="text-gray-400 border-b border-gray-700"><tr><th>#</th><th>User</th><th>Completed</th><th>Approved</th><th>Rejected</th><th>OTD%</th><th>Avg Claim(d)</th><th>Avg Work(d)</th><th>Avg Cycle(d)</th></tr></thead>
-                <tbody>
-                  {leaderboard.map((r, i) => (
-                    <tr key={`${r.user_id}-${i}`} className="border-b border-gray-800 text-gray-200">
-                      <td className="text-gray-400 pr-3">{i + 1}</td>
-                      <td>{r.user_name}</td>
-                      <td>{r.completed || 0}</td>
-                      <td>{r.approved || 0}</td>
-                      <td>{r.rejected || 0}</td>
-                      <td>{pct(r.met_sla || 0, r.considered_sla || 0)}%</td>
-                      <td>{r.avg_claim_d}</td>
-                      <td>{r.avg_work_d}</td>
-                      <td>{r.avg_cycle_d}</td>
-                    </tr>
+                <div className="mt-5 flex flex-wrap gap-2">
+                  {chartSeries.map((item) => (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onClick={() => {
+                        if (item.key === 'other') return;
+                        setFocusedOwnerKey(item.key === focusedOwnerKey ? null : item.key);
+                      }}
+                      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs transition ${focusedOwnerKey === item.key ? 'border-white bg-white/10 text-white' : 'border-white/10 bg-white/5 text-slate-300 hover:bg-white/10'}`}
+                    >
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: item.color }} />
+                      <span>{item.label}</span>
+                      <span className="text-slate-400">{item.total}</span>
+                    </button>
                   ))}
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="overflow-hidden border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.98),rgba(2,6,23,0.97))] text-white shadow-2xl xl:sticky xl:top-24 xl:col-span-4 xl:self-start">
+          <CardHeader className="border-b border-white/10 pb-4">
+            <div className="text-xs uppercase tracking-[0.18em] text-slate-400">Ownership board</div>
+            <CardTitle className="mt-2 text-2xl text-white">Taken vs closed</CardTitle>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              Open owned is live now. Taken, closed, and released-to-finance follow the selected activity range.
+            </p>
+          </CardHeader>
+          <CardContent className="max-h-[520px] space-y-3 overflow-y-auto p-5">
+            {loading ? (
+              <div className="py-20 text-center text-slate-400">Loading ownership board...</div>
+            ) : ownerBoard.length === 0 ? (
+              <div className="py-20 text-center text-slate-400">No reviewer activity found for the selected range.</div>
+            ) : (
+              ownerBoard.map((row) => {
+                const rowFocusKey = row.ownerType === 'reviewer'
+                  ? `queue:${row.ownerKey}`
+                  : row.ownerType === 'unclaimed_finance'
+                    ? 'queue:unclaimed_finance'
+                    : 'queue:unclaimed_admin';
+                const isFocused = focusedOwnerKey === rowFocusKey;
+                const riskLevel = row.overSlaOpen >= 3 ? 'high' : row.overSlaOpen > 0 ? 'medium' : 'low';
+
+                return (
+                  <button
+                    key={row.ownerKey}
+                    type="button"
+                    onClick={() => {
+                      if (ownerMode !== 'queue_owner') {
+                        setOwnerMode('queue_owner');
+                      }
+                      setFocusedOwnerKey(isFocused ? null : rowFocusKey);
+                    }}
+                    className={`w-full rounded-2xl border p-4 text-left transition ${isFocused ? 'border-sky-400/60 bg-sky-400/10' : 'border-white/10 bg-white/5 hover:bg-white/10'}`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="text-base font-semibold text-white">{row.ownerLabel}</div>
+                        <div className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-400">
+                          {row.ownerType === 'reviewer' ? (row.role || 'Reviewer') : row.ownerType === 'unclaimed_finance' ? 'Finance queue' : 'Admin queue'}
+                        </div>
+                      </div>
+                      <Badge className={`border ${riskLevel === 'high' ? 'border-rose-400/40 bg-rose-400/15 text-rose-200' : riskLevel === 'medium' ? 'border-amber-400/40 bg-amber-400/15 text-amber-200' : 'border-emerald-400/40 bg-emerald-400/15 text-emerald-200'}`}>
+                        {row.openOwned} open
+                      </Badge>
+                    </div>
+
+                    <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
+                      <div>
+                        <div className="text-xs uppercase tracking-[0.16em] text-slate-500">Taken</div>
+                        <div className="mt-1 text-lg font-semibold text-white">{row.taken}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-[0.16em] text-slate-500">Closed</div>
+                        <div className="mt-1 text-lg font-semibold text-white">{row.closed}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-[0.16em] text-slate-500">Approved / Rejected</div>
+                        <div className="mt-1 text-lg font-semibold text-white">{row.approved} / {row.rejected}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-[0.16em] text-slate-500">Over SLA Open</div>
+                        <div className="mt-1 text-lg font-semibold text-white">{row.overSlaOpen}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-[0.16em] text-slate-500">Median Close Age</div>
+                        <div className="mt-1 text-lg font-semibold text-white">{formatAgeCompact(row.medianCloseAgeSeconds)}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-[0.16em] text-slate-500">Released to Finance</div>
+                        <div className="mt-1 text-lg font-semibold text-white">{row.releasedToFinance}</div>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="overflow-hidden border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.98),rgba(2,6,23,0.97))] text-white shadow-2xl">
+        <CardHeader className="border-b border-white/10 pb-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <div className="text-xs uppercase tracking-[0.18em] text-slate-400">Action list</div>
+              <CardTitle className="mt-2 text-2xl text-white">Oldest cases needing attention</CardTitle>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                Start here when you want the queue to move. The table is always sorted by current age, oldest first.
+              </p>
+            </div>
+            <div className="text-sm text-slate-400">
+              {focusedOwnerKey ? 'Filtered to selected owner from chart / board' : 'Showing highest-risk open approvals'}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-10 text-center text-slate-400">Loading cases...</div>
+          ) : oldestCases.length === 0 ? (
+            <div className="p-10 text-center text-slate-400">No open cases match the current filters.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-white/10 text-left">
+                <thead className="bg-white/[0.03] text-xs uppercase tracking-[0.18em] text-slate-400">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Quote</th>
+                    <th className="px-4 py-3 font-medium">Customer</th>
+                    <th className="px-4 py-3 font-medium">Sales Owner</th>
+                    <th className="px-4 py-3 font-medium">Queue Owner</th>
+                    <th className="px-4 py-3 font-medium">Lane</th>
+                    <th className="px-4 py-3 font-medium">Current Age</th>
+                    <th className="px-4 py-3 font-medium">Margin Signal</th>
+                    <th className="px-4 py-3 font-medium">Claim</th>
+                    <th className="px-4 py-3 font-medium text-right">Action</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5">
+                  {oldestCases.map((openCase) => {
+                    const marginSignal = openCase.requiresFinanceApproval
+                      ? (openCase.financeLimitPercent != null && openCase.discountedMargin != null
+                        ? `${openCase.discountedMargin.toFixed(1)}% vs ${openCase.financeLimitPercent.toFixed(1)}% guardrail`
+                        : 'Finance review required')
+                      : (openCase.discountedMargin != null ? `${openCase.discountedMargin.toFixed(1)}% margin` : 'Standard review');
+                    const severity = getOpenCaseSeverity(openCase, slaDays);
+
+                    return (
+                      <tr
+                        key={openCase.quoteId}
+                        className={`group cursor-pointer transition ${severity.rowClass}`}
+                        onClick={() => navigate(`/quote/${encodeURIComponent(openCase.quoteId)}`)}
+                      >
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-3">
+                            <span className={`h-2.5 w-2.5 rounded-full ${severity.accentClass}`} />
+                            <span className="font-mono text-sm text-sky-300">{openCase.quoteId}</span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-white">{openCase.customerName}</td>
+                        <td className="px-4 py-3 text-sm text-slate-300">{openCase.salesOwnerLabel}</td>
+                        <td className="px-4 py-3 text-sm text-slate-200">{openCase.queueOwnerLabel}</td>
+                        <td className="px-4 py-3 text-sm">
+                          <Badge className={openCase.lane === 'finance' ? 'border border-amber-400/40 bg-amber-400/15 text-amber-200' : 'border border-sky-400/40 bg-sky-400/15 text-sky-200'}>
+                            {openCase.lane === 'finance' ? 'Finance' : 'Admin'}
+                          </Badge>
+                        </td>
+                        <td className="px-4 py-3 text-sm">
+                          <div className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-semibold ${severity.ageClass}`}>
+                            <span>{formatAgeCompact(openCase.ageSeconds)}</span>
+                            <span className="text-[10px] uppercase tracking-[0.16em] opacity-80">{severity.label}</span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-slate-300">{marginSignal}</td>
+                        <td className="px-4 py-3 text-sm">
+                          <Badge className={openCase.isClaimed ? 'border border-emerald-400/40 bg-emerald-400/15 text-emerald-200' : 'border border-rose-400/40 bg-rose-400/15 text-rose-200'}>
+                            {openCase.isClaimed ? 'Claimed' : 'Unclaimed'}
+                          </Badge>
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <Button
+                            variant="ghost"
+                            className="text-slate-300 hover:bg-white/10 hover:text-white"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              navigate(`/quote/${encodeURIComponent(openCase.quoteId)}`);
+                            }}
+                          >
+                            Open
+                            <ArrowUpRight className="ml-2 h-4 w-4" />
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
-            </CardContent>
-          </Card>
-        </TabsContent>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
-        <TabsContent value="backlog">
-          <Card className="bg-gray-900 border-gray-800"><CardHeader><CardTitle className="text-white">Backlog Aging (Avg Age Trend proxy)</CardTitle></CardHeader><CardContent className="h-72">{loading ? <div className="text-gray-400">Loading...</div> : <ResponsiveContainer width="100%" height="100%"><LineChart data={ts}><CartesianGrid strokeDasharray="3 3" stroke="#334155" /><XAxis dataKey="bucket" stroke="#94a3b8" /><YAxis stroke="#94a3b8" /><Tooltip /><Line type="monotone" dataKey="otd" stroke="#f59e0b" strokeWidth={2} /></LineChart></ResponsiveContainer>}</CardContent></Card>
-        </TabsContent>
-      </Tabs>
     </div>
   );
 }

--- a/src/components/admin/quote-approval/QuoteDetails.tsx
+++ b/src/components/admin/quote-approval/QuoteDetails.tsx
@@ -15,6 +15,10 @@ import { useConfiguredQuoteFields } from "@/hooks/useConfiguredQuoteFields";
 import { FEATURES, usePermissions } from "@/hooks/usePermissions";
 import { extractCommissionFromQuoteFields, calculatePartnerCommission } from "@/utils/marginCalculations";
 import { deriveWorkflowState, getWorkflowLaneForState, isPendingWorkflowState } from "@/lib/workflow/utils";
+
+const canActInAdminLane = (role?: string | null) =>
+  role === 'ADMIN' || role === 'MASTER' || role === 'LEVEL_3';
+
 interface QuoteDetailsProps {
   quote: Quote;
   onApprove: (payload: {
@@ -79,7 +83,7 @@ const QuoteDetails = ({
   const currentLane = getWorkflowLaneForState(workflowState);
   const isWorkflowPending = isPendingWorkflowState(workflowState);
   const userRole = user?.role ?? 'SALES';
-  const canAdminAct = currentLane === 'admin' && (userRole === 'ADMIN' || userRole === 'MASTER');
+  const canAdminAct = currentLane === 'admin' && canActInAdminLane(userRole);
   const canFinanceAct = currentLane === 'finance' && (userRole === 'FINANCE' || userRole === 'MASTER');
   const canCurrentUserAct = canAdminAct || canFinanceAct;
   const reviewedBy = (quote as any).reviewed_by as string | undefined;

--- a/src/services/kpiService.ts
+++ b/src/services/kpiService.ts
@@ -4,6 +4,55 @@ const supabase = getSupabaseClient();
 
 export type KpiBucket = 'day' | 'week' | 'biweek' | 'month';
 export type KpiLane = 'admin' | 'finance' | 'both';
+export type ApprovalAgingLane = 'all' | 'admin' | 'finance';
+
+export interface ApprovalAgingSummary {
+  openCases: number;
+  overSla: number;
+  unclaimedAdmin: number;
+  unclaimedFinance: number;
+  medianOpenAgeSeconds: number | null;
+  oldestOpenAgeSeconds: number | null;
+}
+
+export interface ApprovalAgingOpenCase {
+  quoteId: string;
+  customerName: string;
+  salesOwnerLabel: string;
+  lane: 'admin' | 'finance';
+  queueOwnerKey: string;
+  queueOwnerLabel: string;
+  queueOwnerId: string | null;
+  ageSeconds: number;
+  startedAt: string;
+  isClaimed: boolean;
+  status: string;
+  discountedMargin: number | null;
+  financeLimitPercent: number | null;
+  requiresFinanceApproval: boolean;
+}
+
+export interface ApprovalAgingOwnerBoardRow {
+  ownerKey: string;
+  ownerLabel: string;
+  ownerType: 'reviewer' | 'unclaimed_admin' | 'unclaimed_finance';
+  role: string | null;
+  openOwned: number;
+  taken: number;
+  closed: number;
+  approved: number;
+  rejected: number;
+  releasedToFinance: number;
+  medianCloseAgeSeconds: number | null;
+  overSlaOpen: number;
+}
+
+export interface ApprovalAgingPayload {
+  summary: ApprovalAgingSummary;
+  openCases: ApprovalAgingOpenCase[];
+  ownerBoard: ApprovalAgingOwnerBoardRow[];
+  generatedAt: string;
+}
 
 export interface KpiSummary {
   total_submitted: number;
@@ -76,6 +125,8 @@ interface KpiFactRow {
   finance_work_seconds?: number | null;
 }
 
+type WorkflowQuoteRow = Record<string, any>;
+
 export const secondsToHours = (seconds?: number | null): number =>
   seconds == null ? 0 : Number((seconds / 3600).toFixed(2));
 
@@ -96,6 +147,21 @@ const avg = (values: Array<number | null | undefined>): number | null => {
   const valid = values.filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
   if (!valid.length) return null;
   return valid.reduce((a, b) => a + b, 0) / valid.length;
+};
+
+const median = (values: Array<number | null | undefined>): number | null => {
+  const valid = values
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+    .sort((a, b) => a - b);
+
+  if (!valid.length) return null;
+
+  const mid = Math.floor(valid.length / 2);
+  if (valid.length % 2 === 1) {
+    return valid[mid];
+  }
+
+  return (valid[mid - 1] + valid[mid]) / 2;
 };
 
 const emptyPayload = (): KpiPayload => ({
@@ -151,6 +217,101 @@ const hasMeaningfulRpcData = (payload: any) => {
 const sec = (a?: string | null, b?: string | null) => {
   if (!a || !b) return null;
   return (new Date(b).getTime() - new Date(a).getTime()) / 1000;
+};
+
+const FINAL_STATUSES = new Set(['approved', 'rejected']);
+
+const normalizeText = (value?: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const parseDateValue = (value?: string | null): number | null => {
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : null;
+};
+
+const isWithinRange = (value: string | null | undefined, start: Date, end: Date) => {
+  const ms = parseDateValue(value);
+  if (ms === null) return false;
+  return ms >= start.getTime() && ms <= end.getTime();
+};
+
+const isOpenApprovalStatus = (row: WorkflowQuoteRow) => {
+  const status = String(row.status ?? '').toLowerCase();
+  const workflowState = String(row.workflow_state ?? '').toLowerCase();
+
+  if (FINAL_STATUSES.has(status) || status === 'draft' || status === 'needs_revision') {
+    return false;
+  }
+
+  if (workflowState === 'closed' || workflowState === 'approved' || workflowState === 'rejected' || workflowState === 'needs_revision') {
+    return false;
+  }
+
+  return (
+    status === 'submitted'
+    || status === 'pending_approval'
+    || status === 'under-review'
+    || workflowState === 'submitted'
+    || workflowState === 'admin_review'
+    || workflowState === 'finance_review'
+    || Boolean(row.requires_finance_approval)
+    || Boolean(row.finance_required_at && !row.finance_decision_at)
+  );
+};
+
+const hasFinancePath = (row: WorkflowQuoteRow) => (
+  Boolean(row.finance_required_at)
+  || Boolean(row.finance_claimed_at)
+  || Boolean(row.finance_decision_at)
+  || Boolean(row.finance_reviewer_id)
+  || Boolean(row.finance_decision_status)
+  || String(row.admin_decision_status ?? '') === 'requires_finance'
+  || String(row.workflow_state ?? '') === 'finance_review'
+);
+
+const deriveOpenLane = (row: WorkflowQuoteRow): 'admin' | 'finance' | null => {
+  if (!isOpenApprovalStatus(row)) return null;
+
+  if (
+    Boolean(row.requires_finance_approval)
+    || String(row.workflow_state ?? '').toLowerCase() === 'finance_review'
+    || Boolean(row.finance_required_at && !row.finance_decision_at)
+  ) {
+    return 'finance';
+  }
+
+  return 'admin';
+};
+
+const extractFinanceLimitPercent = (row: WorkflowQuoteRow): number | null => {
+  const snapshot = row.finance_threshold_snapshot;
+  if (!snapshot || typeof snapshot !== 'object') return null;
+
+  const raw = (snapshot as Record<string, unknown>).limitPercent;
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return raw;
+  }
+
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const getQueueOwnerId = (row: WorkflowQuoteRow, lane: 'admin' | 'finance') => {
+  if (lane === 'finance') {
+    return normalizeText(row.finance_reviewer_id);
+  }
+
+  return normalizeText(row.admin_reviewer_id) ?? normalizeText(row.reviewed_by);
 };
 
 const buildPayloadFromFacts = (
@@ -378,6 +539,247 @@ class KpiService {
       };
     });
     return map;
+  }
+
+  async getApprovalAgingDashboard(params: {
+    start: Date;
+    end: Date;
+    lane: ApprovalAgingLane;
+    slaHours: number;
+  }): Promise<ApprovalAgingPayload> {
+    const [quotesResult, factsResult] = await Promise.all([
+      supabase
+        .from('quotes')
+        .select('*')
+        .order('created_at', { ascending: false }),
+      supabase
+        .from('quote_kpi_facts')
+        .select('quote_id,status,workflow_state,submitted_at,submitted_by_email,submitted_by_name,admin_reviewer_id,finance_reviewer_id,requires_finance,admin_claimed_at,admin_decision_at,finance_required_at,finance_claimed_at,finance_decision_at,final_decision_at,total_cycle_seconds'),
+    ]);
+
+    if (quotesResult.error) {
+      throw quotesResult.error;
+    }
+
+    const factsByQuoteId = new Map<string, WorkflowQuoteRow>();
+    if (!factsResult.error && Array.isArray(factsResult.data)) {
+      (factsResult.data as WorkflowQuoteRow[]).forEach((row) => {
+        const quoteId = normalizeText(row.quote_id);
+        if (quoteId) {
+          factsByQuoteId.set(quoteId, row);
+        }
+      });
+    }
+
+    const mergedRows = ((quotesResult.data || []) as WorkflowQuoteRow[]).map((quote) => {
+      const facts = factsByQuoteId.get(String(quote.id)) || {};
+      return {
+        ...quote,
+        ...facts,
+        id: quote.id,
+        customer_name: quote.customer_name,
+        discounted_margin: quote.discounted_margin,
+        finance_threshold_snapshot: quote.finance_threshold_snapshot,
+        requires_finance_approval: quote.requires_finance_approval ?? facts.requires_finance ?? false,
+        submitted_by_name: quote.submitted_by_name ?? facts.submitted_by_name,
+        submitted_by_email: quote.submitted_by_email ?? facts.submitted_by_email,
+      };
+    });
+
+    const reviewerIds = Array.from(
+      new Set(
+        mergedRows.flatMap((row) => [
+          normalizeText(row.admin_reviewer_id),
+          normalizeText(row.finance_reviewer_id),
+          normalizeText(row.reviewed_by),
+        ].filter(Boolean) as string[])
+      )
+    );
+
+    const reviewerMap = reviewerIds.length > 0
+      ? await this.resolveUsers(reviewerIds)
+      : {};
+
+    const now = Date.now();
+    const slaSeconds = params.slaHours * 3600;
+
+    const openCases = mergedRows
+      .map((row) => {
+        const lane = deriveOpenLane(row);
+        if (!lane) return null;
+        if (params.lane !== 'all' && params.lane !== lane) return null;
+
+        const startedAt = normalizeText(row.submitted_at) ?? normalizeText(row.created_at);
+        const startedAtMs = parseDateValue(startedAt);
+        if (!startedAt || startedAtMs === null) return null;
+
+        const queueOwnerId = getQueueOwnerId(row, lane);
+        const queueOwnerLabel = queueOwnerId
+          ? (reviewerMap[queueOwnerId]?.name || reviewerMap[queueOwnerId]?.email || queueOwnerId)
+          : (lane === 'finance' ? 'Unclaimed Finance Queue' : 'Unclaimed Admin Queue');
+
+        return {
+          quoteId: String(row.id),
+          customerName: normalizeText(row.customer_name) || 'Pending Customer',
+          salesOwnerLabel: normalizeText(row.submitted_by_name) || normalizeText(row.submitted_by_email) || 'Unknown requester',
+          lane,
+          queueOwnerKey: queueOwnerId ?? `unclaimed_${lane}`,
+          queueOwnerLabel,
+          queueOwnerId,
+          ageSeconds: Math.max(0, (now - startedAtMs) / 1000),
+          startedAt,
+          isClaimed: Boolean(queueOwnerId),
+          status: String(row.status ?? lane),
+          discountedMargin: toNumberOrNull(row.discounted_margin),
+          financeLimitPercent: extractFinanceLimitPercent(row),
+          requiresFinanceApproval: Boolean(row.requires_finance_approval) || lane === 'finance',
+        } satisfies ApprovalAgingOpenCase;
+      })
+      .filter((value): value is ApprovalAgingOpenCase => Boolean(value))
+      .sort((a, b) => b.ageSeconds - a.ageSeconds);
+
+    type MutableBoardRow = ApprovalAgingOwnerBoardRow & {
+      closeAgeSamples: number[];
+    };
+
+    const boardMap = new Map<string, MutableBoardRow>();
+    const ensureBoardRow = (
+      ownerKey: string,
+      ownerLabel: string,
+      ownerType: ApprovalAgingOwnerBoardRow['ownerType'],
+      role: string | null,
+    ) => {
+      if (!boardMap.has(ownerKey)) {
+        boardMap.set(ownerKey, {
+          ownerKey,
+          ownerLabel,
+          ownerType,
+          role,
+          openOwned: 0,
+          taken: 0,
+          closed: 0,
+          approved: 0,
+          rejected: 0,
+          releasedToFinance: 0,
+          medianCloseAgeSeconds: null,
+          overSlaOpen: 0,
+          closeAgeSamples: [],
+        });
+      }
+
+      return boardMap.get(ownerKey)!;
+    };
+
+    openCases.forEach((openCase) => {
+      const row = ensureBoardRow(
+        openCase.queueOwnerKey,
+        openCase.queueOwnerLabel,
+        openCase.queueOwnerId
+          ? 'reviewer'
+          : (openCase.lane === 'finance' ? 'unclaimed_finance' : 'unclaimed_admin'),
+        openCase.queueOwnerId ? (reviewerMap[openCase.queueOwnerId]?.role || null) : null,
+      );
+
+      row.openOwned += 1;
+      if (openCase.ageSeconds > slaSeconds) {
+        row.overSlaOpen += 1;
+      }
+    });
+
+    mergedRows.forEach((row) => {
+      const startedAt = normalizeText(row.submitted_at) ?? normalizeText(row.created_at);
+      const adminOwnerId = getQueueOwnerId(row, 'admin');
+      const financeOwnerId = getQueueOwnerId(row, 'finance');
+      const adminOwnerLabel = adminOwnerId
+        ? (reviewerMap[adminOwnerId]?.name || reviewerMap[adminOwnerId]?.email || adminOwnerId)
+        : 'Unclaimed Admin Queue';
+      const financeOwnerLabel = financeOwnerId
+        ? (reviewerMap[financeOwnerId]?.name || reviewerMap[financeOwnerId]?.email || financeOwnerId)
+        : 'Unclaimed Finance Queue';
+      const finalStatus = String(row.status ?? '').toLowerCase();
+      const financePath = hasFinancePath(row);
+      const totalCloseAgeSeconds = sec(startedAt, normalizeText(row.finance_decision_at) ?? normalizeText(row.admin_decision_at) ?? normalizeText(row.reviewed_at));
+
+      if (params.lane !== 'finance' && adminOwnerId && isWithinRange(row.admin_claimed_at, params.start, params.end)) {
+        ensureBoardRow(adminOwnerId, adminOwnerLabel, 'reviewer', reviewerMap[adminOwnerId]?.role || null).taken += 1;
+      }
+
+      if (params.lane !== 'admin' && financeOwnerId && isWithinRange(row.finance_claimed_at, params.start, params.end)) {
+        ensureBoardRow(financeOwnerId, financeOwnerLabel, 'reviewer', reviewerMap[financeOwnerId]?.role || null).taken += 1;
+      }
+
+      if (
+        params.lane !== 'finance'
+        && adminOwnerId
+        && String(row.admin_decision_status ?? '') === 'requires_finance'
+        && isWithinRange(row.admin_decision_at, params.start, params.end)
+      ) {
+        ensureBoardRow(adminOwnerId, adminOwnerLabel, 'reviewer', reviewerMap[adminOwnerId]?.role || null).releasedToFinance += 1;
+      }
+
+      const adminClosedDirectly = !financePath
+        && FINAL_STATUSES.has(finalStatus)
+        && isWithinRange(normalizeText(row.admin_decision_at) ?? normalizeText(row.reviewed_at), params.start, params.end);
+
+      if (params.lane !== 'finance' && adminOwnerId && adminClosedDirectly) {
+        const boardRow = ensureBoardRow(adminOwnerId, adminOwnerLabel, 'reviewer', reviewerMap[adminOwnerId]?.role || null);
+        boardRow.closed += 1;
+        if (finalStatus === 'approved') boardRow.approved += 1;
+        if (finalStatus === 'rejected') boardRow.rejected += 1;
+        if (typeof totalCloseAgeSeconds === 'number' && Number.isFinite(totalCloseAgeSeconds)) {
+          boardRow.closeAgeSamples.push(totalCloseAgeSeconds);
+        }
+      }
+
+      const financeClosed = financePath
+        && FINAL_STATUSES.has(finalStatus)
+        && isWithinRange(row.finance_decision_at, params.start, params.end);
+
+      if (params.lane !== 'admin' && financeOwnerId && financeClosed) {
+        const boardRow = ensureBoardRow(financeOwnerId, financeOwnerLabel, 'reviewer', reviewerMap[financeOwnerId]?.role || null);
+        boardRow.closed += 1;
+        if (finalStatus === 'approved') boardRow.approved += 1;
+        if (finalStatus === 'rejected') boardRow.rejected += 1;
+        if (typeof totalCloseAgeSeconds === 'number' && Number.isFinite(totalCloseAgeSeconds)) {
+          boardRow.closeAgeSamples.push(totalCloseAgeSeconds);
+        }
+      }
+    });
+
+    const ownerBoard = Array.from(boardMap.values())
+      .map(({ closeAgeSamples, ...row }) => ({
+        ...row,
+        medianCloseAgeSeconds: median(closeAgeSamples),
+      }))
+      .filter((row) =>
+        row.openOwned > 0
+        || row.taken > 0
+        || row.closed > 0
+        || row.releasedToFinance > 0
+      )
+      .sort((a, b) => {
+        const openDiff = b.openOwned - a.openOwned;
+        if (openDiff !== 0) return openDiff;
+
+        const overSlaDiff = b.overSlaOpen - a.overSlaOpen;
+        if (overSlaDiff !== 0) return overSlaDiff;
+
+        return b.closed - a.closed;
+      });
+
+    return {
+      summary: {
+        openCases: openCases.length,
+        overSla: openCases.filter((row) => row.ageSeconds > slaSeconds).length,
+        unclaimedAdmin: openCases.filter((row) => row.lane === 'admin' && !row.isClaimed).length,
+        unclaimedFinance: openCases.filter((row) => row.lane === 'finance' && !row.isClaimed).length,
+        medianOpenAgeSeconds: median(openCases.map((row) => row.ageSeconds)),
+        oldestOpenAgeSeconds: openCases.length ? openCases[0].ageSeconds : null,
+      },
+      openCases,
+      ownerBoard,
+      generatedAt: new Date().toISOString(),
+    };
   }
 }
 

--- a/supabase/functions/quote-workflow/index.ts
+++ b/supabase/functions/quote-workflow/index.ts
@@ -84,6 +84,29 @@ class HttpError extends Error {
   }
 }
 
+const OPTIONAL_WORKFLOW_COLUMNS = [
+  "workflow_state",
+  "admin_reviewer_id",
+  "finance_reviewer_id",
+  "admin_claimed_at",
+  "finance_claimed_at",
+  "reviewed_at",
+  "reviewed_by",
+  "admin_decision_at",
+  "admin_decision_by",
+  "admin_decision_status",
+  "admin_decision_notes",
+  "finance_required_at",
+  "finance_notes",
+  "finance_decision_by",
+  "finance_decision_at",
+  "finance_decision_status",
+  "finance_decision_notes",
+  "finance_threshold_snapshot",
+  "finance_margin_breached",
+  "requires_finance_approval",
+] as const;
+
 const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
 const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
@@ -149,6 +172,102 @@ serve(async (req) => {
 });
 
 type SupabaseServerClient = SupabaseClient<Database>;
+
+const isRowNotFoundError = (error: { code?: string; message?: string } | null | undefined) => {
+  if (!error) {
+    return false;
+  }
+
+  return error.code === "PGRST116";
+};
+
+const isMissingColumnError = (error: { code?: string; message?: string } | null | undefined) => {
+  if (!error) {
+    return false;
+  }
+
+  if (error.code === "42703" || error.code === "PGRST204") {
+    return true;
+  }
+
+  const message = String(error.message ?? "").toLowerCase();
+  return message.includes("column") && message.includes("does not exist");
+};
+
+const extractMissingColumnName = (error: { message?: string } | null | undefined) => {
+  const message = String(error?.message ?? "");
+  const quoted = message.match(/column\s+"?([a-zA-Z0-9_]+)"?\s+does not exist/i);
+  if (quoted?.[1]) {
+    return quoted[1];
+  }
+
+  const named = message.match(/["']([a-zA-Z0-9_]+)["']/);
+  return named?.[1] ?? null;
+};
+
+async function fetchQuoteById(
+  supabase: SupabaseServerClient,
+  quoteId: string,
+) {
+  const safeQuoteId = quoteId.trim();
+  const result = await supabase
+    .from("quotes")
+    .select("*")
+    .eq("id", safeQuoteId)
+    .single();
+
+  if (result.data) {
+    return result.data;
+  }
+
+  if (isRowNotFoundError(result.error)) {
+    throw new HttpError(404, "Quote not found");
+  }
+
+  throw new HttpError(500, result.error?.message ?? "Unable to load quote");
+}
+
+async function updateQuoteWithLegacyFallback(
+  supabase: SupabaseServerClient,
+  quoteId: string,
+  payload: Record<string, any>,
+) {
+  const safeQuoteId = quoteId.trim();
+  const updatePayload = { ...payload };
+
+  while (true) {
+    const result = await supabase
+      .from("quotes")
+      .update(updatePayload)
+      .eq("id", safeQuoteId)
+      .select("*")
+      .single();
+
+    if (!result.error && result.data) {
+      return result.data;
+    }
+
+    if (!isMissingColumnError(result.error)) {
+      throw new HttpError(400, result.error?.message ?? "Unable to claim quote");
+    }
+
+    const dynamicMissingColumn = extractMissingColumnName(result.error);
+    const missingColumn = (dynamicMissingColumn && dynamicMissingColumn in updatePayload)
+      ? dynamicMissingColumn
+      : OPTIONAL_WORKFLOW_COLUMNS.find((column) => {
+      if (!(column in updatePayload)) {
+        return false;
+      }
+      return String(result.error?.message ?? "").includes(column);
+    });
+
+    if (!missingColumn) {
+      throw new HttpError(400, result.error?.message ?? "Unable to claim quote");
+    }
+
+    delete updatePayload[missingColumn];
+  }
+}
 
 async function getRequestContext(req: Request, supabase: SupabaseServerClient): Promise<RequestContext> {
   const authHeader = req.headers.get("Authorization");
@@ -256,6 +375,10 @@ async function handleClaim(
   if (!quoteId || !lane) {
     throw new HttpError(400, "quoteId and lane are required");
   }
+  const safeQuoteId = String(quoteId).trim();
+  if (!safeQuoteId) {
+    throw new HttpError(400, "quoteId is required");
+  }
 
   if (lane === "admin") {
     assertRole(context, ["ADMIN", "MASTER"]);
@@ -265,17 +388,14 @@ async function handleClaim(
     throw new HttpError(400, "Lane must be admin or finance");
   }
 
-  const { data: before, error: beforeError } = await supabase
-    .from("quotes")
-    .select("id, status, workflow_state, requires_finance_approval, admin_claimed_at, finance_claimed_at")
-    .eq("id", quoteId)
-    .single();
+  const before = await fetchQuoteById(supabase, safeQuoteId);
 
-  if (beforeError || !before) {
-    throw new HttpError(404, "Quote not found");
-  }
+  const statusBefore = String((before as any).status ?? "");
+  const requiresFinanceClaim = Boolean((before as any).requires_finance_approval)
+    || statusBefore === "under-review"
+    || String((before as any).workflow_state ?? "") === "finance_review";
 
-  if (lane === 'finance' && !(before as any).requires_finance_approval) {
+  if (lane === "finance" && !requiresFinanceClaim) {
     throw new HttpError(400, "Quote is not waiting for finance claim");
   }
 
@@ -287,7 +407,7 @@ async function handleClaim(
   const rpcResult = await supabase.rpc("claim_quote_for_review", {
     p_actor_id: context.userId,
     p_lane: lane,
-    p_quote_id: quoteId,
+    p_quote_id: safeQuoteId,
   });
 
   if (!rpcResult.error) {
@@ -309,22 +429,12 @@ async function handleClaim(
       claimPayload.finance_claimed_at = (before as any).finance_claimed_at ?? now;
     }
 
-    const updated = await supabase
-      .from("quotes")
-      .update(claimPayload)
-      .eq("id", quoteId)
-      .select("*")
-      .single();
-
-    if (updated.error || !updated.data) {
-      throw new HttpError(400, rpcResult.error?.message ?? "Unable to claim quote");
-    }
-    data = updated.data;
+    data = await updateQuoteWithLegacyFallback(supabase, safeQuoteId, claimPayload);
   }
 
   await logEvent(
     supabase,
-    quoteId,
+    safeQuoteId,
     lane === "admin" ? "quote_claimed_admin" : "quote_claimed_finance",
     context,
     (before as any).workflow_state ?? (before as any).status ?? null,
@@ -345,16 +455,11 @@ async function handleAdminDecision(
   if (!quoteId || !decision) {
     throw new HttpError(400, "quoteId and decision are required");
   }
-
-  const { data: quote, error } = await supabase
-    .from("quotes")
-    .select("*")
-    .eq("id", quoteId)
-    .single();
-
-  if (error || !quote) {
-    throw new HttpError(404, "Quote not found");
+  const safeQuoteId = String(quoteId).trim();
+  if (!safeQuoteId) {
+    throw new HttpError(400, "quoteId is required");
   }
+  const quote = await fetchQuoteById(supabase, safeQuoteId);
 
   const currentStatus = String((quote as any).status || 'draft');
   const isFinancePending = Boolean((quote as any).requires_finance_approval);
@@ -421,18 +526,9 @@ async function handleAdminDecision(
     nextState = "needs_revision";
   }
 
-  const { data: updatedQuote, error: updateError } = await supabase
-    .from("quotes")
-    .update(updates)
-    .eq("id", quoteId)
-    .select("*")
-    .single();
+  const updatedQuote = await updateQuoteWithLegacyFallback(supabase, safeQuoteId, updates);
 
-  if (updateError || !updatedQuote) {
-    throw new HttpError(500, "Unable to record admin decision");
-  }
-
-  await logEvent(supabase, quoteId, "quote_admin_decision", context, quote.workflow_state, nextState, {
+  await logEvent(supabase, safeQuoteId, "quote_admin_decision", context, quote.workflow_state, nextState, {
     decision,
     notes,
     marginPercent,
@@ -441,7 +537,7 @@ async function handleAdminDecision(
 
   if (decision === "requires_finance") {
     await notifyFinanceReviewRequired(supabase, {
-      quoteId,
+      quoteId: safeQuoteId,
       customerName: updatedQuote.customer_name ?? "Unknown Customer",
       requesterName: context.fullName,
       appUrl: Deno.env.get("APP_DOMAIN") ? `https://${Deno.env.get("APP_DOMAIN")}` : null,
@@ -461,18 +557,16 @@ async function handleFinanceDecision(
   if (!quoteId || !decision) {
     throw new HttpError(400, "quoteId and decision are required");
   }
-
-  const { data: quote, error } = await supabase
-    .from("quotes")
-    .select("*")
-    .eq("id", quoteId)
-    .single();
-
-  if (error || !quote) {
-    throw new HttpError(404, "Quote not found");
+  const safeQuoteId = String(quoteId).trim();
+  if (!safeQuoteId) {
+    throw new HttpError(400, "quoteId is required");
   }
+  const quote = await fetchQuoteById(supabase, safeQuoteId);
 
-  if (!(quote as any).requires_finance_approval) {
+  const financePending = Boolean((quote as any).requires_finance_approval)
+    || String((quote as any).status ?? "") === "under-review"
+    || String((quote as any).workflow_state ?? "") === "finance_review";
+  if (!financePending) {
     throw new HttpError(400, "Quote is not waiting for finance");
   }
 
@@ -498,18 +592,9 @@ async function handleFinanceDecision(
     status: decision === "approved" ? "approved" : "rejected",
   };
 
-  const { data: updatedQuote, error: updateError } = await supabase
-    .from("quotes")
-    .update(updates)
-    .eq("id", quoteId)
-    .select("*")
-    .single();
+  const updatedQuote = await updateQuoteWithLegacyFallback(supabase, safeQuoteId, updates);
 
-  if (updateError || !updatedQuote) {
-    throw new HttpError(500, "Unable to record finance decision");
-  }
-
-  await logEvent(supabase, quoteId, "quote_finance_decision", context, (quote as any).status ?? null, updates.status ?? null, {
+  await logEvent(supabase, safeQuoteId, "quote_finance_decision", context, (quote as any).status ?? null, updates.status ?? null, {
     decision,
     notes,
     marginPercent: margin,


### PR DESCRIPTION
## Summary
- replace the admin KPI page with an approval aging control tower
- add actionable KPI filters, aging visuals, reviewer ownership board, and oldest-case queue table
- harden quote claim/admin/finance workflow handling for legacy schema compatibility
- align admin-lane UI permissions for `LEVEL_3` users
- add the KPI refresh PRD document

## Testing
- npm run build
- redeployed `quote-workflow` edge function to project `cwhmxpitwblqxgrvaigg`
